### PR TITLE
chore: added `src/lib/*` to the CI coverage filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Filter directories
         run: |
           sudo apt update && sudo apt install -y lcov
-          lcov --remove lcov.info 'test/*' 'script/*' --output-file lcov.info --rc lcov_branch_coverage=1
+          lcov --remove lcov.info 'test/*' 'script/*' 'src/lib/*' --output-file lcov.info --rc lcov_branch_coverage=1
 
       # This step posts a detailed coverage report as a comment and deletes previous comments on
       # each push. The below step is used to fail coverage if the specified coverage threshold is


### PR DESCRIPTION
**Motivation:**

CI coverage is not passing due to 0% coverage for all of the `.sol` files in the `src/lib/` directory

**Modifications:**

added src/lib to the ci filter

**Result:**

Coverage will be more accurate