### PR TITLE
refactor: prefix token voting file and contract names with llama

### DIFF
--- a/script/DeployLlamaTokenVotingFactory.s.sol
+++ b/script/DeployLlamaTokenVotingFactory.s.sol
@@ -4,18 +4,18 @@ pragma solidity 0.8.23;
 import {Script} from "forge-std/Script.sol";
 
 import {DeployUtils} from "script/DeployUtils.sol";
-import {LlamaERC20TokenHolderActionCreator} from "src/token-voting/LlamaERC20TokenHolderActionCreator.sol";
-import {LlamaERC20TokenHolderCaster} from "src/token-voting/LlamaERC20TokenHolderCaster.sol";
-import {LlamaERC721TokenHolderActionCreator} from "src/token-voting/LlamaERC721TokenHolderActionCreator.sol";
-import {LlamaERC721TokenHolderCaster} from "src/token-voting/LlamaERC721TokenHolderCaster.sol";
+import {LlamaERC20TokenActionCreator} from "src/token-voting/LlamaERC20TokenActionCreator.sol";
+import {LlamaERC20TokenCaster} from "src/token-voting/LlamaERC20TokenCaster.sol";
+import {LlamaERC721TokenActionCreator} from "src/token-voting/LlamaERC721TokenActionCreator.sol";
+import {LlamaERC721TokenCaster} from "src/token-voting/LlamaERC721TokenCaster.sol";
 import {LlamaTokenVotingFactory} from "src/token-voting/LlamaTokenVotingFactory.sol";
 
 contract DeployLlamaTokenVotingFactory is Script {
   // Logic contracts.
-  LlamaERC20TokenHolderActionCreator llamaERC20TokenHolderActionCreatorLogic;
-  LlamaERC20TokenHolderCaster llamaERC20TokenHolderCasterLogic;
-  LlamaERC721TokenHolderActionCreator llamaERC721TokenHolderActionCreatorLogic;
-  LlamaERC721TokenHolderCaster llamaERC721TokenHolderCasterLogic;
+  LlamaERC20TokenActionCreator llamaERC20TokenActionCreatorLogic;
+  LlamaERC20TokenCaster llamaERC20TokenCasterLogic;
+  LlamaERC721TokenActionCreator llamaERC721TokenActionCreatorLogic;
+  LlamaERC721TokenCaster llamaERC721TokenCasterLogic;
 
   // Factory contracts.
   LlamaTokenVotingFactory tokenVotingFactory;
@@ -26,39 +26,33 @@ contract DeployLlamaTokenVotingFactory is Script {
     );
 
     vm.broadcast();
-    llamaERC20TokenHolderActionCreatorLogic = new LlamaERC20TokenHolderActionCreator();
+    llamaERC20TokenActionCreatorLogic = new LlamaERC20TokenActionCreator();
     DeployUtils.print(
-      string.concat(
-        "  LlamaERC20TokenHolderActionCreatorLogic: ", vm.toString(address(llamaERC20TokenHolderActionCreatorLogic))
-      )
+      string.concat("  LlamaERC20TokenActionCreatorLogic: ", vm.toString(address(llamaERC20TokenActionCreatorLogic)))
     );
 
     vm.broadcast();
-    llamaERC20TokenHolderCasterLogic = new LlamaERC20TokenHolderCaster();
+    llamaERC20TokenCasterLogic = new LlamaERC20TokenCaster();
+    DeployUtils.print(string.concat("  LlamaERC20TokenCasterLogic: ", vm.toString(address(llamaERC20TokenCasterLogic))));
+
+    vm.broadcast();
+    llamaERC721TokenActionCreatorLogic = new LlamaERC721TokenActionCreator();
     DeployUtils.print(
-      string.concat("  LlamaERC20TokenHolderCasterLogic: ", vm.toString(address(llamaERC20TokenHolderCasterLogic)))
+      string.concat("  LlamaERC721TokenActionCreatorLogic: ", vm.toString(address(llamaERC721TokenActionCreatorLogic)))
     );
 
     vm.broadcast();
-    llamaERC721TokenHolderActionCreatorLogic = new LlamaERC721TokenHolderActionCreator();
+    llamaERC721TokenCasterLogic = new LlamaERC721TokenCaster();
     DeployUtils.print(
-      string.concat(
-        "  LlamaERC721TokenHolderActionCreatorLogic: ", vm.toString(address(llamaERC721TokenHolderActionCreatorLogic))
-      )
-    );
-
-    vm.broadcast();
-    llamaERC721TokenHolderCasterLogic = new LlamaERC721TokenHolderCaster();
-    DeployUtils.print(
-      string.concat("  LlamaERC721TokenHolderCasterLogic: ", vm.toString(address(llamaERC721TokenHolderCasterLogic)))
+      string.concat("  LlamaERC721TokenCasterLogic: ", vm.toString(address(llamaERC721TokenCasterLogic)))
     );
 
     vm.broadcast();
     tokenVotingFactory = new LlamaTokenVotingFactory(
-      llamaERC20TokenHolderActionCreatorLogic,
-      llamaERC20TokenHolderCasterLogic,
-      llamaERC721TokenHolderActionCreatorLogic,
-      llamaERC721TokenHolderCasterLogic
+      llamaERC20TokenActionCreatorLogic,
+      llamaERC20TokenCasterLogic,
+      llamaERC721TokenActionCreatorLogic,
+      llamaERC721TokenCasterLogic
     );
     DeployUtils.print(string.concat("  LlamaTokenVotingFactory: ", vm.toString(address(tokenVotingFactory))));
   }

--- a/src/token-voting/LlamaERC20TokenActionCreator.sol
+++ b/src/token-voting/LlamaERC20TokenActionCreator.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.8.23;
 
 import {ILlamaCore} from "src/interfaces/ILlamaCore.sol";
-import {LlamaTokenHolderCaster} from "src/token-voting/LlamaTokenHolderCaster.sol";
+import {LlamaTokenActionCreator} from "src/token-voting/LlamaTokenActionCreator.sol";
 import {ERC20Votes} from "@openzeppelin/token/ERC20/extensions/ERC20Votes.sol";
 
-/// @title LlamaERC20TokenHolderCaster
+/// @title LlamaERC20TokenActionCreator
 /// @author Llama (devsdosomething@llama.xyz)
-/// @notice This contract lets holders of a given governance ERC20Votes token cast approvals and disapprovals
-/// on created actions.
-contract LlamaERC20TokenHolderCaster is LlamaTokenHolderCaster {
+/// @notice This contract lets holders of a specified `ERC20Votes` token create actions on a llama instance if their
+/// token balance is greater than or equal to the creation threshold.
+contract LlamaERC20TokenActionCreator is LlamaTokenActionCreator {
   ERC20Votes public token;
 
   /// @dev This contract is deployed as a minimal proxy from the factory's `deployTokenVotingModule` function. The
@@ -18,25 +18,24 @@ contract LlamaERC20TokenHolderCaster is LlamaTokenHolderCaster {
     _disableInitializers();
   }
 
-  /// @notice Initializes a new `LlamaERC20TokenHolderCaster` clone.
+  /// @notice Initializes a new `LlamaERC20TokenActionCreator` clone.
   /// @dev This function is called by the `deployTokenVotingModule` function in the `LlamaTokenVotingFactory` contract.
   /// The `initializer` modifier ensures that this function can be invoked at most once.
   /// @param _token The ERC20 token to be used for voting.
   /// @param _llamaCore The `LlamaCore` contract for this Llama instance.
   /// @param _role The role used by this contract to cast approvals and disapprovals.
-  /// @param _minApprovalPct The minimum % of approvals required to submit approvals to `LlamaCore`.
-  /// @param _minDisapprovalPct The minimum % of disapprovals required to submit disapprovals to `LlamaCore`.
-  function initialize(
-    ERC20Votes _token,
-    ILlamaCore _llamaCore,
-    uint8 _role,
-    uint256 _minApprovalPct,
-    uint256 _minDisapprovalPct
-  ) external initializer {
-    __initializeLlamaTokenHolderCasterMinimalProxy(_llamaCore, _role, _minApprovalPct, _minDisapprovalPct);
+  /// @param _creationThreshold The default number of tokens required to create an action. This must
+  /// be in the same decimals as the token. For example, if the token has 18 decimals and you want a
+  /// creation threshold of 1000 tokens, pass in 1000e18.
+  function initialize(ERC20Votes _token, ILlamaCore _llamaCore, uint8 _role, uint256 _creationThreshold)
+    external
+    initializer
+  {
+    __initializeLlamaTokenActionCreatorMinimalProxy(_llamaCore, _role, _creationThreshold);
     token = _token;
     uint256 totalSupply = token.totalSupply();
     if (totalSupply == 0) revert InvalidTokenAddress();
+    if (_creationThreshold > totalSupply) revert InvalidCreationThreshold();
   }
 
   function _getPastVotes(address account, uint256 timestamp) internal view virtual override returns (uint256) {

--- a/src/token-voting/LlamaERC20TokenCaster.sol
+++ b/src/token-voting/LlamaERC20TokenCaster.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.8.23;
 
 import {ILlamaCore} from "src/interfaces/ILlamaCore.sol";
-import {LlamaTokenHolderActionCreator} from "src/token-voting/LlamaTokenHolderActionCreator.sol";
+import {LlamaTokenCaster} from "src/token-voting/LlamaTokenCaster.sol";
 import {ERC20Votes} from "@openzeppelin/token/ERC20/extensions/ERC20Votes.sol";
 
-/// @title LlamaERC20TokenHolderActionCreator
+/// @title LlamaERC20TokenCaster
 /// @author Llama (devsdosomething@llama.xyz)
-/// @notice This contract lets holders of a specified `ERC20Votes` token create actions on a llama instance if their
-/// token balance is greater than or equal to the creation threshold.
-contract LlamaERC20TokenHolderActionCreator is LlamaTokenHolderActionCreator {
+/// @notice This contract lets holders of a given governance ERC20Votes token cast approvals and disapprovals
+/// on created actions.
+contract LlamaERC20TokenCaster is LlamaTokenCaster {
   ERC20Votes public token;
 
   /// @dev This contract is deployed as a minimal proxy from the factory's `deployTokenVotingModule` function. The
@@ -18,24 +18,25 @@ contract LlamaERC20TokenHolderActionCreator is LlamaTokenHolderActionCreator {
     _disableInitializers();
   }
 
-  /// @notice Initializes a new `LlamaERC20TokenHolderActionCreator` clone.
+  /// @notice Initializes a new `LlamaERC20TokenCaster` clone.
   /// @dev This function is called by the `deployTokenVotingModule` function in the `LlamaTokenVotingFactory` contract.
   /// The `initializer` modifier ensures that this function can be invoked at most once.
   /// @param _token The ERC20 token to be used for voting.
   /// @param _llamaCore The `LlamaCore` contract for this Llama instance.
   /// @param _role The role used by this contract to cast approvals and disapprovals.
-  /// @param _creationThreshold The default number of tokens required to create an action. This must
-  /// be in the same decimals as the token. For example, if the token has 18 decimals and you want a
-  /// creation threshold of 1000 tokens, pass in 1000e18.
-  function initialize(ERC20Votes _token, ILlamaCore _llamaCore, uint8 _role, uint256 _creationThreshold)
-    external
-    initializer
-  {
-    __initializeLlamaTokenHolderActionCreatorMinimalProxy(_llamaCore, _role, _creationThreshold);
+  /// @param _minApprovalPct The minimum % of approvals required to submit approvals to `LlamaCore`.
+  /// @param _minDisapprovalPct The minimum % of disapprovals required to submit disapprovals to `LlamaCore`.
+  function initialize(
+    ERC20Votes _token,
+    ILlamaCore _llamaCore,
+    uint8 _role,
+    uint256 _minApprovalPct,
+    uint256 _minDisapprovalPct
+  ) external initializer {
+    __initializeLlamaTokenCasterMinimalProxy(_llamaCore, _role, _minApprovalPct, _minDisapprovalPct);
     token = _token;
     uint256 totalSupply = token.totalSupply();
     if (totalSupply == 0) revert InvalidTokenAddress();
-    if (_creationThreshold > totalSupply) revert InvalidCreationThreshold();
   }
 
   function _getPastVotes(address account, uint256 timestamp) internal view virtual override returns (uint256) {

--- a/src/token-voting/LlamaERC721TokenActionCreator.sol
+++ b/src/token-voting/LlamaERC721TokenActionCreator.sol
@@ -2,15 +2,15 @@
 pragma solidity ^0.8.23;
 
 import {ILlamaCore} from "src/interfaces/ILlamaCore.sol";
-import {LlamaTokenHolderCaster} from "src/token-voting/LlamaTokenHolderCaster.sol";
+import {LlamaTokenActionCreator} from "src/token-voting/LlamaTokenActionCreator.sol";
 import {ERC721Votes} from "@openzeppelin/token/ERC721/extensions/ERC721Votes.sol";
 import {IERC721} from "@openzeppelin/token/ERC721/IERC721.sol";
 
-/// @title LlamaERC721TokenHolderCaster
+/// @title LlamaERC721TokenActionCreator
 /// @author Llama (devsdosomething@llama.xyz)
-/// @notice This contract lets holders of a given governance ERC721Votes token cast approvals and disapprovals
-/// on created actions.
-contract LlamaERC721TokenHolderCaster is LlamaTokenHolderCaster {
+/// @notice This contract lets holders of a given governance ERC721Votes token create actions on the llama instance if
+/// they hold enough tokens.
+contract LlamaERC721TokenActionCreator is LlamaTokenActionCreator {
   ERC721Votes public token;
 
   /// @dev This contract is deployed as a minimal proxy from the factory's `deployTokenVotingModule` function. The
@@ -19,24 +19,25 @@ contract LlamaERC721TokenHolderCaster is LlamaTokenHolderCaster {
     _disableInitializers();
   }
 
-  /// @notice Initializes a new `LlamaERC721TokenHolderCaster` clone.
+  /// @notice Initializes a new `LlamaERC721TokenActionCreator` clone.
   /// @dev This function is called by the `deployTokenVotingModule` function in the `LlamaTokenVotingFactory` contract.
   /// The `initializer` modifier ensures that this function can be invoked at most once.
   /// @param _token The ERC721 token to be used for voting.
   /// @param _llamaCore The `LlamaCore` contract for this Llama instance.
   /// @param _role The role used by this contract to cast approvals and disapprovals.
-  /// @param _minApprovalPct The minimum % of approvals required to submit approvals to `LlamaCore`.
-  /// @param _minDisapprovalPct The minimum % of disapprovals required to submit disapprovals to `LlamaCore`.
-  function initialize(
-    ERC721Votes _token,
-    ILlamaCore _llamaCore,
-    uint8 _role,
-    uint256 _minApprovalPct,
-    uint256 _minDisapprovalPct
-  ) external initializer {
-    __initializeLlamaTokenHolderCasterMinimalProxy(_llamaCore, _role, _minApprovalPct, _minDisapprovalPct);
+  /// @param _creationThreshold The default number of tokens required to create an action. This must
+  /// be in the same decimals as the token. For example, if the token has 18 decimals and you want a
+  /// creation threshold of 1000 tokens, pass in 1000e18.
+  function initialize(ERC721Votes _token, ILlamaCore _llamaCore, uint8 _role, uint256 _creationThreshold)
+    external
+    initializer
+  {
+    __initializeLlamaTokenActionCreatorMinimalProxy(_llamaCore, _role, _creationThreshold);
     token = _token;
     if (!token.supportsInterface(type(IERC721).interfaceId)) revert InvalidTokenAddress();
+    uint256 totalSupply = token.getPastTotalSupply(block.timestamp - 1);
+    if (totalSupply == 0) revert InvalidTokenAddress();
+    if (_creationThreshold > totalSupply) revert InvalidCreationThreshold();
   }
 
   function _getPastVotes(address account, uint256 timestamp) internal view virtual override returns (uint256) {

--- a/src/token-voting/LlamaTokenActionCreator.sol
+++ b/src/token-voting/LlamaTokenActionCreator.sol
@@ -8,7 +8,7 @@ import {ILlamaStrategy} from "src/interfaces/ILlamaStrategy.sol";
 import {Action, ActionInfo} from "src/lib/Structs.sol";
 import {LlamaUtils} from "src/lib/LlamaUtils.sol";
 
-/// @title LlamaTokenHolderActionCreator
+/// @title LlamaTokenActionCreator
 /// @author Llama (devsdosomething@llama.xyz)
 /// @notice This contract lets holders of a given governance token create actions if they have
 /// sufficient token balance.
@@ -16,7 +16,7 @@ import {LlamaUtils} from "src/lib/LlamaUtils.sol";
 /// it must hold a Policy from the specified `LlamaCore` instance to actually be able to create an action. The
 /// instance's policy encodes what actions this contract is allowed to create, and attempting to create an action that
 /// is not allowed by the policy will result in a revert.
-abstract contract LlamaTokenHolderActionCreator is Initializable {
+abstract contract LlamaTokenActionCreator is Initializable {
   /// @notice The core contract for this Llama instance.
   ILlamaCore public llamaCore;
 
@@ -109,7 +109,7 @@ abstract contract LlamaTokenHolderActionCreator is Initializable {
   /// @param _creationThreshold The default number of tokens required to create an action. This must
   /// be in the same decimals as the token. For example, if the token has 18 decimals and you want a
   /// creation threshold of 1000 tokens, pass in 1000e18.
-  function __initializeLlamaTokenHolderActionCreatorMinimalProxy(
+  function __initializeLlamaTokenActionCreatorMinimalProxy(
     ILlamaCore _llamaCore,
     uint8 _role,
     uint256 _creationThreshold

--- a/src/token-voting/LlamaTokenCaster.sol
+++ b/src/token-voting/LlamaTokenCaster.sol
@@ -10,7 +10,7 @@ import {LlamaUtils} from "src/lib/LlamaUtils.sol";
 import {Action, ActionInfo} from "src/lib/Structs.sol";
 import {ILlamaRelativeStrategyBase} from "src/interfaces/ILlamaRelativeStrategyBase.sol";
 
-/// @title LlamaTokenHolderCaster
+/// @title LlamaTokenCaster
 /// @author Llama (devsdosomething@llama.xyz)
 /// @notice This contract lets holders of a given governance token cast approvals and disapprovals
 /// on created actions.
@@ -18,7 +18,7 @@ import {ILlamaRelativeStrategyBase} from "src/interfaces/ILlamaRelativeStrategyB
 /// it must hold a Policy from the specified `LlamaCore` instance to actually be able to cast on an action. This
 /// contract does not verify that it holds the correct policy when voting and relies on `LlamaCore` to
 /// verify that during submission.
-abstract contract LlamaTokenHolderCaster is Initializable {
+abstract contract LlamaTokenCaster is Initializable {
   // =========================
   // ======== Structs ========
   // =========================
@@ -188,7 +188,7 @@ abstract contract LlamaTokenHolderCaster is Initializable {
   /// @param _role The role used by this contract to cast approvals and disapprovals.
   /// @param _minApprovalPct The minimum % of approvals required to submit approvals to `LlamaCore`.
   /// @param _minDisapprovalPct The minimum % of disapprovals required to submit disapprovals to `LlamaCore`.
-  function __initializeLlamaTokenHolderCasterMinimalProxy(
+  function __initializeLlamaTokenCasterMinimalProxy(
     ILlamaCore _llamaCore,
     uint8 _role,
     uint256 _minApprovalPct,

--- a/src/token-voting/LlamaTokenVotingFactory.sol
+++ b/src/token-voting/LlamaTokenVotingFactory.sol
@@ -4,11 +4,11 @@ pragma solidity ^0.8.23;
 import {Clones} from "@openzeppelin/proxy/Clones.sol";
 
 import {ILlamaCore} from "src/interfaces/ILlamaCore.sol";
-import {LlamaERC20TokenHolderActionCreator} from "src/token-voting/LlamaERC20TokenHolderActionCreator.sol";
-import {LlamaERC20TokenHolderCaster} from "src/token-voting/LlamaERC20TokenHolderCaster.sol";
+import {LlamaERC20TokenActionCreator} from "src/token-voting/LlamaERC20TokenActionCreator.sol";
+import {LlamaERC20TokenCaster} from "src/token-voting/LlamaERC20TokenCaster.sol";
 import {ERC20Votes} from "@openzeppelin/token/ERC20/extensions/ERC20Votes.sol";
-import {LlamaERC721TokenHolderActionCreator} from "src/token-voting/LlamaERC721TokenHolderActionCreator.sol";
-import {LlamaERC721TokenHolderCaster} from "src/token-voting/LlamaERC721TokenHolderCaster.sol";
+import {LlamaERC721TokenActionCreator} from "src/token-voting/LlamaERC721TokenActionCreator.sol";
+import {LlamaERC721TokenCaster} from "src/token-voting/LlamaERC721TokenCaster.sol";
 import {ERC721Votes} from "@openzeppelin/token/ERC721/extensions/ERC721Votes.sol";
 
 /// @title LlamaTokenVotingFactory
@@ -17,38 +17,38 @@ import {ERC721Votes} from "@openzeppelin/token/ERC721/extensions/ERC721Votes.sol
 contract LlamaTokenVotingFactory {
   error NoModulesDeployed();
 
-  event LlamaERC20TokenHolderActionCreatorCreated(address actionCreator, address indexed token);
-  event LlamaERC721TokenHolderActionCreatorCreated(address actionCreator, address indexed token);
-  event LlamaERC20TokenHolderCasterCreated(
+  event LlamaERC20TokenActionCreatorCreated(address actionCreator, address indexed token);
+  event LlamaERC721TokenActionCreatorCreated(address actionCreator, address indexed token);
+  event LlamaERC20TokenCasterCreated(
     address caster, address indexed token, uint256 minApprovalPct, uint256 minDisapprovalPct
   );
-  event LlamaERC721TokenHolderCasterCreated(
+  event LlamaERC721TokenCasterCreated(
     address caster, address indexed token, uint256 minApprovalPct, uint256 minDisapprovalPct
   );
 
   /// @notice The ERC20 Tokenholder Action Creator (logic) contract.
-  LlamaERC20TokenHolderActionCreator public immutable ERC20_TOKENHOLDER_ACTION_CREATOR_LOGIC;
+  LlamaERC20TokenActionCreator public immutable ERC20_TOKENHOLDER_ACTION_CREATOR_LOGIC;
 
   /// @notice The ERC20 Tokenholder Caster (logic) contract.
-  LlamaERC20TokenHolderCaster public immutable ERC20_TOKENHOLDER_CASTER_LOGIC;
+  LlamaERC20TokenCaster public immutable ERC20_TOKENHOLDER_CASTER_LOGIC;
 
   /// @notice The ERC721 Tokenholder Action Creator (logic) contract.
-  LlamaERC721TokenHolderActionCreator public immutable ERC721_TOKENHOLDER_ACTION_CREATOR_LOGIC;
+  LlamaERC721TokenActionCreator public immutable ERC721_TOKENHOLDER_ACTION_CREATOR_LOGIC;
 
   /// @notice The ERC721 Tokenholder Caster (logic) contract.
-  LlamaERC721TokenHolderCaster public immutable ERC721_TOKENHOLDER_CASTER_LOGIC;
+  LlamaERC721TokenCaster public immutable ERC721_TOKENHOLDER_CASTER_LOGIC;
 
   /// @dev Set the logic contracts used to deploy Token Voting modules.
   constructor(
-    LlamaERC20TokenHolderActionCreator llamaERC20TokenHolderActionCreatorLogic,
-    LlamaERC20TokenHolderCaster llamaERC20TokenHolderCasterLogic,
-    LlamaERC721TokenHolderActionCreator llamaERC721TokenHolderActionCreatorLogic,
-    LlamaERC721TokenHolderCaster llamaERC721TokenHolderCasterLogic
+    LlamaERC20TokenActionCreator llamaERC20TokenActionCreatorLogic,
+    LlamaERC20TokenCaster llamaERC20TokenCasterLogic,
+    LlamaERC721TokenActionCreator llamaERC721TokenActionCreatorLogic,
+    LlamaERC721TokenCaster llamaERC721TokenCasterLogic
   ) {
-    ERC20_TOKENHOLDER_ACTION_CREATOR_LOGIC = llamaERC20TokenHolderActionCreatorLogic;
-    ERC20_TOKENHOLDER_CASTER_LOGIC = llamaERC20TokenHolderCasterLogic;
-    ERC721_TOKENHOLDER_ACTION_CREATOR_LOGIC = llamaERC721TokenHolderActionCreatorLogic;
-    ERC721_TOKENHOLDER_CASTER_LOGIC = llamaERC721TokenHolderCasterLogic;
+    ERC20_TOKENHOLDER_ACTION_CREATOR_LOGIC = llamaERC20TokenActionCreatorLogic;
+    ERC20_TOKENHOLDER_CASTER_LOGIC = llamaERC20TokenCasterLogic;
+    ERC721_TOKENHOLDER_ACTION_CREATOR_LOGIC = llamaERC721TokenActionCreatorLogic;
+    ERC721_TOKENHOLDER_CASTER_LOGIC = llamaERC721TokenCasterLogic;
   }
 
   ///@notice Deploys a token voting module in a single function so it can be deployed in a single llama action.
@@ -57,8 +57,8 @@ contract LlamaTokenVotingFactory {
   /// a script.
   ///@param token The address of the token to be used for voting.
   ///@param isERC20 Whether the token is an ERC20 or ERC721.
-  ///@param actionCreatorRole The role required by the LlamaTokenHolderActionCreator to create an action.
-  ///@param casterRole The role required by the LlamaTokenHolderCaster to cast approvals and disapprovals.
+  ///@param actionCreatorRole The role required by the LlamaTokenActionCreator to create an action.
+  ///@param casterRole The role required by the LlamaTokenCaster to cast approvals and disapprovals.
   ///@param creationThreshold The number of tokens required to create an action (set to 0 if not deploying action
   /// creator).
   ///@param minApprovalPct The minimum percentage of tokens required to approve an action (set to 0 if not deploying
@@ -76,20 +76,17 @@ contract LlamaTokenVotingFactory {
     uint256 minDisapprovalPct
   ) external returns (address actionCreator, address caster) {
     if (isERC20) {
-      actionCreator = address(
-        _deployLlamaERC20TokenHolderActionCreator(ERC20Votes(token), llamaCore, actionCreatorRole, creationThreshold)
-      );
+      actionCreator =
+        address(_deployLlamaERC20TokenActionCreator(ERC20Votes(token), llamaCore, actionCreatorRole, creationThreshold));
       caster = address(
-        _deployLlamaERC20TokenHolderCaster(ERC20Votes(token), llamaCore, casterRole, minApprovalPct, minDisapprovalPct)
+        _deployLlamaERC20TokenCaster(ERC20Votes(token), llamaCore, casterRole, minApprovalPct, minDisapprovalPct)
       );
     } else {
       actionCreator = address(
-        _deployLlamaERC721TokenHolderActionCreator(ERC721Votes(token), llamaCore, actionCreatorRole, creationThreshold)
+        _deployLlamaERC721TokenActionCreator(ERC721Votes(token), llamaCore, actionCreatorRole, creationThreshold)
       );
       caster = address(
-        _deployLlamaERC721TokenHolderCaster(
-          ERC721Votes(token), llamaCore, casterRole, minApprovalPct, minDisapprovalPct
-        )
+        _deployLlamaERC721TokenCaster(ERC721Votes(token), llamaCore, casterRole, minApprovalPct, minDisapprovalPct)
       );
     }
   }
@@ -98,65 +95,65 @@ contract LlamaTokenVotingFactory {
   // ======== Internal Functions ========
   // ====================================
 
-  function _deployLlamaERC20TokenHolderActionCreator(
+  function _deployLlamaERC20TokenActionCreator(
     ERC20Votes token,
     ILlamaCore llamaCore,
     uint8 role,
     uint256 creationThreshold
-  ) internal returns (LlamaERC20TokenHolderActionCreator actionCreator) {
-    actionCreator = LlamaERC20TokenHolderActionCreator(
+  ) internal returns (LlamaERC20TokenActionCreator actionCreator) {
+    actionCreator = LlamaERC20TokenActionCreator(
       Clones.cloneDeterministic(
         address(ERC20_TOKENHOLDER_ACTION_CREATOR_LOGIC), keccak256(abi.encodePacked(address(token), msg.sender))
       )
     );
     actionCreator.initialize(token, llamaCore, role, creationThreshold);
-    emit LlamaERC20TokenHolderActionCreatorCreated(address(actionCreator), address(token));
+    emit LlamaERC20TokenActionCreatorCreated(address(actionCreator), address(token));
   }
 
-  function _deployLlamaERC721TokenHolderActionCreator(
+  function _deployLlamaERC721TokenActionCreator(
     ERC721Votes token,
     ILlamaCore llamaCore,
     uint8 role,
     uint256 creationThreshold
-  ) internal returns (LlamaERC721TokenHolderActionCreator actionCreator) {
-    actionCreator = LlamaERC721TokenHolderActionCreator(
+  ) internal returns (LlamaERC721TokenActionCreator actionCreator) {
+    actionCreator = LlamaERC721TokenActionCreator(
       Clones.cloneDeterministic(
         address(ERC721_TOKENHOLDER_ACTION_CREATOR_LOGIC), keccak256(abi.encodePacked(address(token), msg.sender))
       )
     );
     actionCreator.initialize(token, llamaCore, role, creationThreshold);
-    emit LlamaERC721TokenHolderActionCreatorCreated(address(actionCreator), address(token));
+    emit LlamaERC721TokenActionCreatorCreated(address(actionCreator), address(token));
   }
 
-  function _deployLlamaERC20TokenHolderCaster(
+  function _deployLlamaERC20TokenCaster(
     ERC20Votes token,
     ILlamaCore llamaCore,
     uint8 role,
     uint256 minApprovalPct,
     uint256 minDisapprovalPct
-  ) internal returns (LlamaERC20TokenHolderCaster caster) {
-    caster = LlamaERC20TokenHolderCaster(
+  ) internal returns (LlamaERC20TokenCaster caster) {
+    caster = LlamaERC20TokenCaster(
       Clones.cloneDeterministic(
         address(ERC20_TOKENHOLDER_CASTER_LOGIC), keccak256(abi.encodePacked(address(token), msg.sender))
       )
     );
     caster.initialize(token, llamaCore, role, minApprovalPct, minDisapprovalPct);
-    emit LlamaERC20TokenHolderCasterCreated(address(caster), address(token), minApprovalPct, minDisapprovalPct);
+    emit LlamaERC20TokenCasterCreated(address(caster), address(token), minApprovalPct, minDisapprovalPct);
   }
 
-  function _deployLlamaERC721TokenHolderCaster(
+  function _deployLlamaERC721TokenCaster(
     ERC721Votes token,
     ILlamaCore llamaCore,
     uint8 role,
     uint256 minApprovalPct,
     uint256 minDisapprovalPct
-  ) internal returns (LlamaERC721TokenHolderCaster caster) {
-    caster = LlamaERC721TokenHolderCaster(
+  ) internal returns (LlamaERC721TokenCaster caster) {
+    caster = LlamaERC721TokenCaster(
       Clones.cloneDeterministic(
         address(ERC721_TOKENHOLDER_CASTER_LOGIC), keccak256(abi.encodePacked(address(token), msg.sender))
       )
     );
     caster.initialize(token, llamaCore, role, minApprovalPct, minDisapprovalPct);
-    emit LlamaERC721TokenHolderCasterCreated(address(caster), address(token), minApprovalPct, minDisapprovalPct);
+    emit LlamaERC721TokenCasterCreated(address(caster), address(token), minApprovalPct, minDisapprovalPct);
   }
 }

--- a/test/token-voting/LlamaERC20TokenActionCreator.t.sol
+++ b/test/token-voting/LlamaERC20TokenActionCreator.t.sol
@@ -10,10 +10,10 @@ import {ILlamaCore} from "src/interfaces/ILlamaCore.sol";
 import {ILlamaStrategy} from "src/interfaces/ILlamaStrategy.sol";
 import {ActionState} from "src/lib/Enums.sol";
 import {Action, ActionInfo} from "src/lib/Structs.sol";
-import {LlamaERC20TokenHolderActionCreator} from "src/token-voting/LlamaERC20TokenHolderActionCreator.sol";
-import {LlamaTokenHolderActionCreator} from "src/token-voting/LlamaTokenHolderActionCreator.sol";
+import {LlamaERC20TokenActionCreator} from "src/token-voting/LlamaERC20TokenActionCreator.sol";
+import {LlamaTokenActionCreator} from "src/token-voting/LlamaTokenActionCreator.sol";
 
-contract LlamaERC20TokenHolderActionCreatorTest is LlamaTokenVotingTestSetup, LlamaCoreSigUtils {
+contract LlamaERC20TokenActionCreatorTest is LlamaTokenVotingTestSetup, LlamaCoreSigUtils {
   event ActionCreated(
     uint256 id,
     address indexed creator,
@@ -29,7 +29,7 @@ contract LlamaERC20TokenHolderActionCreatorTest is LlamaTokenVotingTestSetup, Ll
 
   event ActionThresholdSet(uint256 newThreshold);
 
-  LlamaERC20TokenHolderActionCreator llamaERC20TokenHolderActionCreator;
+  LlamaERC20TokenActionCreator llamaERC20TokenActionCreator;
 
   function setUp() public virtual override {
     LlamaTokenVotingTestSetup.setUp();
@@ -42,7 +42,7 @@ contract LlamaERC20TokenHolderActionCreatorTest is LlamaTokenVotingTestSetup, Ll
     mineBlock();
 
     // Deploy ERC20 Token Voting Module.
-    (llamaERC20TokenHolderActionCreator,) = _deployERC20TokenVotingModuleAndSetRole();
+    (llamaERC20TokenActionCreator,) = _deployERC20TokenVotingModuleAndSetRole();
 
     // Setting ERC20TokenHolderActionCreator's EIP-712 Domain Hash
     setDomainHash(
@@ -50,22 +50,22 @@ contract LlamaERC20TokenHolderActionCreatorTest is LlamaTokenVotingTestSetup, Ll
         name: CORE.name(),
         version: "1",
         chainId: block.chainid,
-        verifyingContract: address(llamaERC20TokenHolderActionCreator)
+        verifyingContract: address(llamaERC20TokenActionCreator)
       })
     );
   }
 }
 
-// contract Constructor is LlamaERC20TokenHolderActionCreatorTest {
+// contract Constructor is LlamaERC20TokenActionCreatorTest {
 //   function test_RevertsIf_InvalidLlamaCore() public {
-//     // With invalid LlamaCore instance, LlamaTokenHolderActionCreator.InvalidLlamaCoreAddress is unreachable
+//     // With invalid LlamaCore instance, LlamaTokenActionCreator.InvalidLlamaCoreAddress is unreachable
 //     vm.expectRevert();
-//     new LlamaERC20TokenHolderActionCreator(erc20VotesToken, ILlamaCore(makeAddr("invalid-llama-core")), uint256(0));
+//     new LlamaERC20TokenActionCreator(erc20VotesToken, ILlamaCore(makeAddr("invalid-llama-core")), uint256(0));
 //   }
 
 //   function test_RevertsIf_InvalidTokenAddress() public {
 //     vm.expectRevert(); // will EvmError: Revert vecause totalSupply fn does not exist
-//     new LlamaERC20TokenHolderActionCreator(ERC20Votes(makeAddr("invalid-erc20VotesToken")), CORE, uint256(0));
+//     new LlamaERC20TokenActionCreator(ERC20Votes(makeAddr("invalid-erc20VotesToken")), CORE, uint256(0));
 //   }
 
 //   function test_RevertsIf_CreationThresholdExceedsTotalSupply() public {
@@ -74,8 +74,8 @@ contract LlamaERC20TokenHolderActionCreatorTest is LlamaTokenVotingTestSetup, Ll
 
 //     vm.warp(block.timestamp + 1);
 
-//     vm.expectRevert(LlamaTokenHolderActionCreator.InvalidCreationThreshold.selector);
-//     new LlamaERC20TokenHolderActionCreator(erc20VotesToken, CORE, 17_000_000_000_000_000_000_000_000);
+//     vm.expectRevert(LlamaTokenActionCreator.InvalidCreationThreshold.selector);
+//     new LlamaERC20TokenActionCreator(erc20VotesToken, CORE, 17_000_000_000_000_000_000_000_000);
 //   }
 
 //   function test_ProperlySetsConstructorArguments() public {
@@ -85,17 +85,17 @@ contract LlamaERC20TokenHolderActionCreatorTest is LlamaTokenVotingTestSetup, Ll
 
 //     vm.warp(block.timestamp + 1);
 
-//     LlamaERC20TokenHolderActionCreator llamaERC20TokenHolderActionCreator = new
-// LlamaERC20TokenHolderActionCreator(erc20VotesToken,
+//     LlamaERC20TokenActionCreator llamaERC20TokenActionCreator = new
+// LlamaERC20TokenActionCreator(erc20VotesToken,
 // CORE,
 // threshold);
-//     assertEq(address(llamaERC20TokenHolderActionCreator.TOKEN()), address(erc20VotesToken));
-//     assertEq(address(llamaERC20TokenHolderActionCreator.LLAMA_CORE()), address(CORE));
-//     assertEq(llamaERC20TokenHolderActionCreator.creationThreshold(), threshold);
+//     assertEq(address(llamaERC20TokenActionCreator.TOKEN()), address(erc20VotesToken));
+//     assertEq(address(llamaERC20TokenActionCreator.LLAMA_CORE()), address(CORE));
+//     assertEq(llamaERC20TokenActionCreator.creationThreshold(), threshold);
 //   }
 // }
 
-contract CreateAction is LlamaERC20TokenHolderActionCreatorTest {
+contract CreateAction is LlamaERC20TokenActionCreatorTest {
   bytes data = abi.encodeCall(mockProtocol.pause, (true));
 
   function test_RevertsIf_InsufficientBalance() public {
@@ -105,12 +105,12 @@ contract CreateAction is LlamaERC20TokenHolderActionCreatorTest {
 
     mineBlock();
 
-    vm.expectRevert(abi.encodeWithSelector(LlamaTokenHolderActionCreator.InsufficientBalance.selector, 0));
+    vm.expectRevert(abi.encodeWithSelector(LlamaTokenActionCreator.InsufficientBalance.selector, 0));
     vm.prank(notTokenHolder);
-    llamaERC20TokenHolderActionCreator.createAction(STRATEGY, address(mockProtocol), 0, data, "");
+    llamaERC20TokenActionCreator.createAction(STRATEGY, address(mockProtocol), 0, data, "");
   }
 
-  function test_RevertsIf_LlamaTokenHolderActionCreatorDoesNotHavePermission() public {
+  function test_RevertsIf_LlamaTokenActionCreatorDoesNotHavePermission() public {
     erc20VotesToken.mint(tokenHolder1, ERC20_CREATION_THRESHOLD);
     vm.prank(tokenHolder1);
     erc20VotesToken.delegate(tokenHolder1);
@@ -119,12 +119,12 @@ contract CreateAction is LlamaERC20TokenHolderActionCreatorTest {
 
     vm.expectRevert(ILlamaCore.PolicyholderDoesNotHavePermission.selector);
     vm.prank(tokenHolder1);
-    llamaERC20TokenHolderActionCreator.createAction(STRATEGY, address(mockProtocol), 0, data, "");
+    llamaERC20TokenActionCreator.createAction(STRATEGY, address(mockProtocol), 0, data, "");
   }
 
   function test_ProperlyCreatesAction() public {
-    // Assigns Permission to LlamaTokenHolderActionCreator.
-    _setRolePermissionToLlamaTokenHolderActionCreator();
+    // Assigns Permission to LlamaTokenActionCreator.
+    _setRolePermissionToLlamaTokenActionCreator();
 
     // Mint tokens to tokenholder so that they can create action.
     erc20VotesToken.mint(tokenHolder1, ERC20_CREATION_THRESHOLD);
@@ -141,7 +141,7 @@ contract CreateAction is LlamaERC20TokenHolderActionCreatorTest {
       actionCount, address(tokenHolder1), tokenVotingActionCreatorRole, STRATEGY, address(mockProtocol), 0, data, ""
     );
     vm.prank(tokenHolder1);
-    uint256 actionId = llamaERC20TokenHolderActionCreator.createAction(STRATEGY, address(mockProtocol), 0, data, "");
+    uint256 actionId = llamaERC20TokenActionCreator.createAction(STRATEGY, address(mockProtocol), 0, data, "");
 
     Action memory action = CORE.getAction(actionId);
     assertEq(actionId, actionCount);
@@ -149,12 +149,12 @@ contract CreateAction is LlamaERC20TokenHolderActionCreatorTest {
   }
 }
 
-contract CreateActionBySig is LlamaERC20TokenHolderActionCreatorTest {
+contract CreateActionBySig is LlamaERC20TokenActionCreatorTest {
   function setUp() public virtual override {
-    LlamaERC20TokenHolderActionCreatorTest.setUp();
+    LlamaERC20TokenActionCreatorTest.setUp();
 
-    // Assigns Permission to LlamaTokenHolderActionCreator.
-    _setRolePermissionToLlamaTokenHolderActionCreator();
+    // Assigns Permission to LlamaTokenActionCreator.
+    _setRolePermissionToLlamaTokenActionCreator();
 
     // Mint tokens to tokenholder so that they can create action.
     erc20VotesToken.mint(tokenHolder1, ERC20_CREATION_THRESHOLD);
@@ -188,7 +188,7 @@ contract CreateActionBySig is LlamaERC20TokenHolderActionCreatorTest {
   }
 
   function createActionBySig(uint8 v, bytes32 r, bytes32 s) internal returns (uint256 actionId) {
-    actionId = llamaERC20TokenHolderActionCreator.createActionBySig(
+    actionId = llamaERC20TokenActionCreator.createActionBySig(
       tokenHolder1, STRATEGY, address(mockProtocol), 0, abi.encodeCall(mockProtocol.pause, (true)), "", v, r, s
     );
   }
@@ -231,7 +231,7 @@ contract CreateActionBySig is LlamaERC20TokenHolderActionCreatorTest {
       "# Action 0 \n This is my action."
     );
 
-    uint256 actionId = llamaERC20TokenHolderActionCreator.createActionBySig(
+    uint256 actionId = llamaERC20TokenActionCreator.createActionBySig(
       tokenHolder1,
       STRATEGY,
       address(mockProtocol),
@@ -251,15 +251,9 @@ contract CreateActionBySig is LlamaERC20TokenHolderActionCreatorTest {
 
   function test_CheckNonceIncrements() public {
     (uint8 v, bytes32 r, bytes32 s) = createOffchainSignature(tokenHolder1PrivateKey);
-    assertEq(
-      llamaERC20TokenHolderActionCreator.nonces(tokenHolder1, LlamaTokenHolderActionCreator.createActionBySig.selector),
-      0
-    );
+    assertEq(llamaERC20TokenActionCreator.nonces(tokenHolder1, LlamaTokenActionCreator.createActionBySig.selector), 0);
     createActionBySig(v, r, s);
-    assertEq(
-      llamaERC20TokenHolderActionCreator.nonces(tokenHolder1, LlamaTokenHolderActionCreator.createActionBySig.selector),
-      1
-    );
+    assertEq(llamaERC20TokenActionCreator.nonces(tokenHolder1, LlamaTokenActionCreator.createActionBySig.selector), 1);
   }
 
   function test_OperationCannotBeReplayed() public {
@@ -267,7 +261,7 @@ contract CreateActionBySig is LlamaERC20TokenHolderActionCreatorTest {
     createActionBySig(v, r, s);
     // Invalid Signature error since the recovered signer address during the second call is not the same as
     // policyholder since nonce has increased.
-    vm.expectRevert(LlamaTokenHolderActionCreator.InvalidSignature.selector);
+    vm.expectRevert(LlamaTokenActionCreator.InvalidSignature.selector);
     createActionBySig(v, r, s);
   }
 
@@ -276,7 +270,7 @@ contract CreateActionBySig is LlamaERC20TokenHolderActionCreatorTest {
     (uint8 v, bytes32 r, bytes32 s) = createOffchainSignature(randomSignerPrivateKey);
     // Invalid Signature error since the recovered signer address is not the same as the policyholder passed in as
     // parameter.
-    vm.expectRevert(LlamaTokenHolderActionCreator.InvalidSignature.selector);
+    vm.expectRevert(LlamaTokenActionCreator.InvalidSignature.selector);
     createActionBySig(v, r, s);
   }
 
@@ -284,7 +278,7 @@ contract CreateActionBySig is LlamaERC20TokenHolderActionCreatorTest {
     (uint8 v, bytes32 r, bytes32 s) = createOffchainSignature(tokenHolder1PrivateKey);
     // Invalid Signature error since the recovered signer address is zero address due to invalid signature values
     // (v,r,s).
-    vm.expectRevert(LlamaTokenHolderActionCreator.InvalidSignature.selector);
+    vm.expectRevert(LlamaTokenActionCreator.InvalidSignature.selector);
     createActionBySig((v + 1), r, s);
   }
 
@@ -292,24 +286,24 @@ contract CreateActionBySig is LlamaERC20TokenHolderActionCreatorTest {
     (uint8 v, bytes32 r, bytes32 s) = createOffchainSignature(tokenHolder1PrivateKey);
 
     vm.prank(tokenHolder1);
-    llamaERC20TokenHolderActionCreator.incrementNonce(LlamaTokenHolderActionCreator.createActionBySig.selector);
+    llamaERC20TokenActionCreator.incrementNonce(LlamaTokenActionCreator.createActionBySig.selector);
 
     // Invalid Signature error since the recovered signer address during the call is not the same as policyholder
     // since nonce has increased.
-    vm.expectRevert(LlamaTokenHolderActionCreator.InvalidSignature.selector);
+    vm.expectRevert(LlamaTokenActionCreator.InvalidSignature.selector);
     createActionBySig(v, r, s);
   }
 }
 
-contract CancelAction is LlamaERC20TokenHolderActionCreatorTest {
+contract CancelAction is LlamaERC20TokenActionCreatorTest {
   uint256 actionId;
   ActionInfo actionInfo;
 
   function setUp() public virtual override {
-    LlamaERC20TokenHolderActionCreatorTest.setUp();
+    LlamaERC20TokenActionCreatorTest.setUp();
 
-    // Assigns Permission to LlamaTokenHolderActionCreator.
-    _setRolePermissionToLlamaTokenHolderActionCreator();
+    // Assigns Permission to LlamaTokenActionCreator.
+    _setRolePermissionToLlamaTokenActionCreator();
 
     // Mint tokens to tokenholder so that they can create action.
     erc20VotesToken.mint(tokenHolder1, ERC20_CREATION_THRESHOLD);
@@ -322,11 +316,11 @@ contract CancelAction is LlamaERC20TokenHolderActionCreatorTest {
     bytes memory data = abi.encodeCall(mockProtocol.pause, (true));
 
     vm.prank(tokenHolder1);
-    actionId = llamaERC20TokenHolderActionCreator.createAction(STRATEGY, address(mockProtocol), 0, data, "");
+    actionId = llamaERC20TokenActionCreator.createAction(STRATEGY, address(mockProtocol), 0, data, "");
 
     actionInfo = ActionInfo(
       actionId,
-      address(llamaERC20TokenHolderActionCreator),
+      address(llamaERC20TokenActionCreator),
       tokenVotingActionCreatorRole,
       STRATEGY,
       address(mockProtocol),
@@ -339,26 +333,26 @@ contract CancelAction is LlamaERC20TokenHolderActionCreatorTest {
     vm.expectEmit();
     emit ActionCanceled(actionId, tokenHolder1);
     vm.prank(tokenHolder1);
-    llamaERC20TokenHolderActionCreator.cancelAction(actionInfo);
+    llamaERC20TokenActionCreator.cancelAction(actionInfo);
   }
 
   function test_RevertsIf_CallerIsNotActionCreator(address notCreator) public {
     vm.assume(notCreator != tokenHolder1);
-    vm.expectRevert(LlamaTokenHolderActionCreator.OnlyActionCreator.selector);
+    vm.expectRevert(LlamaTokenActionCreator.OnlyActionCreator.selector);
     vm.prank(notCreator);
-    llamaERC20TokenHolderActionCreator.cancelAction(actionInfo);
+    llamaERC20TokenActionCreator.cancelAction(actionInfo);
   }
 }
 
-contract CancelActionBySig is LlamaERC20TokenHolderActionCreatorTest {
+contract CancelActionBySig is LlamaERC20TokenActionCreatorTest {
   uint256 actionId;
   ActionInfo actionInfo;
 
   function setUp() public virtual override {
-    LlamaERC20TokenHolderActionCreatorTest.setUp();
+    LlamaERC20TokenActionCreatorTest.setUp();
 
-    // Assigns Permission to LlamaTokenHolderActionCreator.
-    _setRolePermissionToLlamaTokenHolderActionCreator();
+    // Assigns Permission to LlamaTokenActionCreator.
+    _setRolePermissionToLlamaTokenActionCreator();
 
     // Mint tokens to tokenholder so that they can create action.
     erc20VotesToken.mint(tokenHolder1, ERC20_CREATION_THRESHOLD);
@@ -371,11 +365,11 @@ contract CancelActionBySig is LlamaERC20TokenHolderActionCreatorTest {
     bytes memory data = abi.encodeCall(mockProtocol.pause, (true));
 
     vm.prank(tokenHolder1);
-    actionId = llamaERC20TokenHolderActionCreator.createAction(STRATEGY, address(mockProtocol), 0, data, "");
+    actionId = llamaERC20TokenActionCreator.createAction(STRATEGY, address(mockProtocol), 0, data, "");
 
     actionInfo = ActionInfo(
       actionId,
-      address(llamaERC20TokenHolderActionCreator),
+      address(llamaERC20TokenActionCreator),
       tokenVotingActionCreatorRole,
       STRATEGY,
       address(mockProtocol),
@@ -392,16 +386,14 @@ contract CancelActionBySig is LlamaERC20TokenHolderActionCreatorTest {
     LlamaCoreSigUtils.CancelAction memory cancelAction = LlamaCoreSigUtils.CancelAction({
       tokenHolder: tokenHolder1,
       actionInfo: _actionInfo,
-      nonce: llamaERC20TokenHolderActionCreator.nonces(
-        tokenHolder1, LlamaTokenHolderActionCreator.cancelActionBySig.selector
-        )
+      nonce: llamaERC20TokenActionCreator.nonces(tokenHolder1, LlamaTokenActionCreator.cancelActionBySig.selector)
     });
     bytes32 digest = getCancelActionTypedDataHash(cancelAction);
     (v, r, s) = vm.sign(privateKey, digest);
   }
 
   function cancelActionBySig(ActionInfo memory _actionInfo, uint8 v, bytes32 r, bytes32 s) internal {
-    llamaERC20TokenHolderActionCreator.cancelActionBySig(tokenHolder1, _actionInfo, v, r, s);
+    llamaERC20TokenActionCreator.cancelActionBySig(tokenHolder1, _actionInfo, v, r, s);
   }
 
   function test_CancelActionBySig() public {
@@ -419,15 +411,9 @@ contract CancelActionBySig is LlamaERC20TokenHolderActionCreatorTest {
   function test_CheckNonceIncrements() public {
     (uint8 v, bytes32 r, bytes32 s) = createOffchainSignature(actionInfo, tokenHolder1PrivateKey);
 
-    assertEq(
-      llamaERC20TokenHolderActionCreator.nonces(tokenHolder1, LlamaTokenHolderActionCreator.cancelActionBySig.selector),
-      0
-    );
+    assertEq(llamaERC20TokenActionCreator.nonces(tokenHolder1, LlamaTokenActionCreator.cancelActionBySig.selector), 0);
     cancelActionBySig(actionInfo, v, r, s);
-    assertEq(
-      llamaERC20TokenHolderActionCreator.nonces(tokenHolder1, LlamaTokenHolderActionCreator.cancelActionBySig.selector),
-      1
-    );
+    assertEq(llamaERC20TokenActionCreator.nonces(tokenHolder1, LlamaTokenActionCreator.cancelActionBySig.selector), 1);
   }
 
   function test_OperationCannotBeReplayed() public {
@@ -435,7 +421,7 @@ contract CancelActionBySig is LlamaERC20TokenHolderActionCreatorTest {
     cancelActionBySig(actionInfo, v, r, s);
     // Invalid Signature error since the recovered signer address during the second call is not the same as policyholder
     // since nonce has increased.
-    vm.expectRevert(LlamaTokenHolderActionCreator.InvalidSignature.selector);
+    vm.expectRevert(LlamaTokenActionCreator.InvalidSignature.selector);
     cancelActionBySig(actionInfo, v, r, s);
   }
 
@@ -444,7 +430,7 @@ contract CancelActionBySig is LlamaERC20TokenHolderActionCreatorTest {
     (uint8 v, bytes32 r, bytes32 s) = createOffchainSignature(actionInfo, randomSignerPrivateKey);
     // Invalid Signature error since the recovered signer address is not the same as the policyholder passed in as
     // parameter.
-    vm.expectRevert(LlamaTokenHolderActionCreator.InvalidSignature.selector);
+    vm.expectRevert(LlamaTokenActionCreator.InvalidSignature.selector);
     cancelActionBySig(actionInfo, v, r, s);
   }
 
@@ -452,7 +438,7 @@ contract CancelActionBySig is LlamaERC20TokenHolderActionCreatorTest {
     (uint8 v, bytes32 r, bytes32 s) = createOffchainSignature(actionInfo, tokenHolder1PrivateKey);
     // Invalid Signature error since the recovered signer address is zero address due to invalid signature values
     // (v,r,s).
-    vm.expectRevert(LlamaTokenHolderActionCreator.InvalidSignature.selector);
+    vm.expectRevert(LlamaTokenActionCreator.InvalidSignature.selector);
     cancelActionBySig(actionInfo, (v + 1), r, s);
   }
 
@@ -460,42 +446,42 @@ contract CancelActionBySig is LlamaERC20TokenHolderActionCreatorTest {
     (uint8 v, bytes32 r, bytes32 s) = createOffchainSignature(actionInfo, tokenHolder1PrivateKey);
 
     vm.prank(tokenHolder1);
-    llamaERC20TokenHolderActionCreator.incrementNonce(LlamaTokenHolderActionCreator.cancelActionBySig.selector);
+    llamaERC20TokenActionCreator.incrementNonce(LlamaTokenActionCreator.cancelActionBySig.selector);
 
     // Invalid Signature error since the recovered signer address during the call is not the same as policyholder
     // since nonce has increased.
-    vm.expectRevert(LlamaTokenHolderActionCreator.InvalidSignature.selector);
+    vm.expectRevert(LlamaTokenActionCreator.InvalidSignature.selector);
     cancelActionBySig(actionInfo, v, r, s);
   }
 }
 
-contract SetActionThreshold is LlamaERC20TokenHolderActionCreatorTest {
+contract SetActionThreshold is LlamaERC20TokenActionCreatorTest {
   function testFuzz_SetsCreationThreshold(uint256 threshold) public {
     threshold = bound(threshold, 0, erc20VotesToken.getPastTotalSupply(block.timestamp - 1));
 
-    assertEq(llamaERC20TokenHolderActionCreator.creationThreshold(), ERC20_CREATION_THRESHOLD);
+    assertEq(llamaERC20TokenActionCreator.creationThreshold(), ERC20_CREATION_THRESHOLD);
 
     vm.expectEmit();
     emit ActionThresholdSet(threshold);
     vm.prank(address(EXECUTOR));
-    llamaERC20TokenHolderActionCreator.setActionThreshold(threshold);
+    llamaERC20TokenActionCreator.setActionThreshold(threshold);
 
-    assertEq(llamaERC20TokenHolderActionCreator.creationThreshold(), threshold);
+    assertEq(llamaERC20TokenActionCreator.creationThreshold(), threshold);
   }
 
   function testFuzz_RevertsIf_CreationThresholdExceedsTotalSupply(uint256 threshold) public {
     vm.assume(threshold > erc20VotesToken.getPastTotalSupply(block.timestamp - 1));
 
-    vm.expectRevert(LlamaTokenHolderActionCreator.InvalidCreationThreshold.selector);
+    vm.expectRevert(LlamaTokenActionCreator.InvalidCreationThreshold.selector);
     vm.prank(address(EXECUTOR));
-    llamaERC20TokenHolderActionCreator.setActionThreshold(threshold);
+    llamaERC20TokenActionCreator.setActionThreshold(threshold);
   }
 
   function testFuzz_RevertsIf_CalledByNotLlamaExecutor(address notLlamaExecutor) public {
     vm.assume(notLlamaExecutor != address(EXECUTOR));
 
-    vm.expectRevert(LlamaTokenHolderActionCreator.OnlyLlamaExecutor.selector);
+    vm.expectRevert(LlamaTokenActionCreator.OnlyLlamaExecutor.selector);
     vm.prank(notLlamaExecutor);
-    llamaERC20TokenHolderActionCreator.setActionThreshold(ERC20_CREATION_THRESHOLD);
+    llamaERC20TokenActionCreator.setActionThreshold(ERC20_CREATION_THRESHOLD);
   }
 }

--- a/test/token-voting/LlamaERC20TokenCaster.t.sol
+++ b/test/token-voting/LlamaERC20TokenCaster.t.sol
@@ -13,10 +13,10 @@ import {Action, ActionInfo, PermissionData} from "src/lib/Structs.sol";
 import {ILlamaCore} from "src/interfaces/ILlamaCore.sol";
 import {ILlamaRelativeStrategyBase} from "src/interfaces/ILlamaRelativeStrategyBase.sol";
 import {ILlamaStrategy} from "src/interfaces/ILlamaStrategy.sol";
-import {LlamaERC721TokenHolderCaster} from "src/token-voting/LlamaERC721TokenHolderCaster.sol";
-import {LlamaTokenHolderCaster} from "src/token-voting/LlamaTokenHolderCaster.sol";
+import {LlamaERC20TokenCaster} from "src/token-voting/LlamaERC20TokenCaster.sol";
+import {LlamaTokenCaster} from "src/token-voting/LlamaTokenCaster.sol";
 
-contract LlamaERC721TokenHolderCasterTest is LlamaTokenVotingTestSetup, LlamaCoreSigUtils {
+contract LlamaERC20TokenCasterTest is LlamaTokenVotingTestSetup, LlamaCoreSigUtils {
   event ApprovalCast(
     uint256 id, address indexed policyholder, uint8 indexed role, uint8 indexed support, uint256 quantity, string reason
   );
@@ -30,31 +30,31 @@ contract LlamaERC721TokenHolderCasterTest is LlamaTokenVotingTestSetup, LlamaCor
   event DisapprovalsSubmitted(uint256 id, uint96 quantityFor, uint96 quantityAgainst, uint96 quantityAbstain);
 
   ActionInfo actionInfo;
-  LlamaERC721TokenHolderCaster llamaERC721TokenHolderCaster;
+  LlamaERC20TokenCaster llamaERC20TokenCaster;
   ILlamaStrategy tokenVotingStrategy;
 
   function setUp() public virtual override {
     LlamaTokenVotingTestSetup.setUp();
 
     // Mint tokens to tokenholders so that there is an existing supply
-    erc721VotesToken.mint(tokenHolder1, 0);
+    erc20VotesToken.mint(tokenHolder1, ERC20_CREATION_THRESHOLD / 2);
     vm.prank(tokenHolder1);
-    erc721VotesToken.delegate(tokenHolder1);
+    erc20VotesToken.delegate(tokenHolder1);
 
-    erc721VotesToken.mint(tokenHolder2, 1);
+    erc20VotesToken.mint(tokenHolder2, ERC20_CREATION_THRESHOLD / 2);
     vm.prank(tokenHolder2);
-    erc721VotesToken.delegate(tokenHolder2);
+    erc20VotesToken.delegate(tokenHolder2);
 
-    erc721VotesToken.mint(tokenHolder3, 2);
+    erc20VotesToken.mint(tokenHolder3, ERC20_CREATION_THRESHOLD / 2);
     vm.prank(tokenHolder3);
-    erc721VotesToken.delegate(tokenHolder3);
+    erc20VotesToken.delegate(tokenHolder3);
 
     // Mine block so that the ERC20 and ERC721 supply will be available when doing a past timestamp check at initialize
     // during deployment.
     mineBlock();
 
     // Deploy ERC20 Token Voting Module.
-    (, llamaERC721TokenHolderCaster) = _deployERC721TokenVotingModuleAndSetRole();
+    (, llamaERC20TokenCaster) = _deployERC20TokenVotingModuleAndSetRole();
 
     // Mine block so that Token Voting Caster Role will have supply during action creation (due to past timestamp check)
     mineBlock();
@@ -62,115 +62,111 @@ contract LlamaERC721TokenHolderCasterTest is LlamaTokenVotingTestSetup, LlamaCor
     tokenVotingStrategy = _deployRelativeQuantityQuorumAndSetRolePermissionToCoreTeam(tokenVotingCasterRole);
     actionInfo = _createActionWithTokenVotingStrategy(tokenVotingStrategy);
 
-    // Setting LlamaERC721TokenHolderCaster's EIP-712 Domain Hash
+    // Setting LlamaERC20TokenCaster's EIP-712 Domain Hash
     setDomainHash(
       LlamaCoreSigUtils.EIP712Domain({
         name: CORE.name(),
         version: "1",
         chainId: block.chainid,
-        verifyingContract: address(llamaERC721TokenHolderCaster)
+        verifyingContract: address(llamaERC20TokenCaster)
       })
     );
   }
 
   function castApprovalsFor() public {
     vm.prank(tokenHolder1);
-    llamaERC721TokenHolderCaster.castApproval(actionInfo, 1, "");
+    llamaERC20TokenCaster.castApproval(actionInfo, 1, "");
     vm.prank(tokenHolder2);
-    llamaERC721TokenHolderCaster.castApproval(actionInfo, 1, "");
+    llamaERC20TokenCaster.castApproval(actionInfo, 1, "");
     vm.prank(tokenHolder3);
-    llamaERC721TokenHolderCaster.castApproval(actionInfo, 1, "");
+    llamaERC20TokenCaster.castApproval(actionInfo, 1, "");
   }
 
   function castDisapprovalsFor() public {
     vm.prank(tokenHolder1);
-    llamaERC721TokenHolderCaster.castDisapproval(actionInfo, 1, "");
+    llamaERC20TokenCaster.castDisapproval(actionInfo, 1, "");
     vm.prank(tokenHolder2);
-    llamaERC721TokenHolderCaster.castDisapproval(actionInfo, 1, "");
+    llamaERC20TokenCaster.castDisapproval(actionInfo, 1, "");
     vm.prank(tokenHolder3);
-    llamaERC721TokenHolderCaster.castDisapproval(actionInfo, 1, "");
+    llamaERC20TokenCaster.castDisapproval(actionInfo, 1, "");
   }
 }
 
-// contract Constructor is LlamaERC721TokenHolderCasterTest {
+// contract Constructor is LlamaERC20TokenCasterTest {
 //   function test_RevertsIf_InvalidLlamaCoreAddress() public {
-//     // With invalid LlamaCore instance, LlamaTokenHolderActionCreator.InvalidLlamaCoreAddress is unreachable
+//     // With invalid LlamaCore instance, LlamaTokenActionCreator.InvalidLlamaCoreAddress is unreachable
 //     vm.expectRevert();
-//     new LlamaERC721TokenHolderCaster(
-//       erc721VotesToken, ILlamaCore(makeAddr("invalid-llama-core")), tokenVotingCasterRole, uint256(1), uint256(1)
+//     new LlamaERC20TokenCaster(
+//       erc20VotesToken, ILlamaCore(makeAddr("invalid-llama-core")), tokenVotingCasterRole, uint256(1), uint256(1)
 //     );
 //   }
 
 //   function test_RevertsIf_InvalidTokenAddress(address notAToken) public {
 //     vm.assume(notAToken != address(0));
-//     vm.assume(notAToken != address(erc721VotesToken));
+//     vm.assume(notAToken != address(erc20VotesToken));
 //     vm.expectRevert(); // will revert with EvmError: Revert because `totalSupply` is not a function
-//     new LlamaERC721TokenHolderCaster(
+//     new LlamaERC20TokenCaster(
 //       ERC20Votes(notAToken), ILlamaCore(address(CORE)), tokenVotingCasterRole, uint256(1), uint256(1)
 //     );
 //   }
 
 //   function test_RevertsIf_InvalidRole(uint8 role) public {
 //     role = uint8(bound(role, POLICY.numRoles(), 255));
-//     vm.expectRevert(abi.encodeWithSelector(LlamaTokenHolderCaster.RoleNotInitialized.selector, uint8(255)));
-//     new LlamaERC721TokenHolderCaster(erc721VotesToken, ILlamaCore(address(CORE)), uint8(255), uint256(1),
-// uint256(1));
+//     vm.expectRevert(abi.encodeWithSelector(LlamaTokenCaster.RoleNotInitialized.selector, uint8(255)));
+//     new LlamaERC20TokenCaster(erc20VotesToken, ILlamaCore(address(CORE)), uint8(255), uint256(1), uint256(1));
 //   }
 
 //   function test_RevertsIf_InvalidMinApprovalPct() public {
-//     vm.expectRevert(abi.encodeWithSelector(LlamaTokenHolderCaster.InvalidMinApprovalPct.selector, uint256(0)));
-//     new LlamaERC721TokenHolderCaster(erc721VotesToken, ILlamaCore(address(CORE)), tokenVotingCasterRole, uint256(0),
+//     vm.expectRevert(abi.encodeWithSelector(LlamaTokenCaster.InvalidMinApprovalPct.selector, uint256(0)));
+//     new LlamaERC20TokenCaster(erc20VotesToken, ILlamaCore(address(CORE)), tokenVotingCasterRole, uint256(0),
 // uint256(1));
-//     vm.expectRevert(abi.encodeWithSelector(LlamaTokenHolderCaster.InvalidMinApprovalPct.selector, uint256(10_001)));
-//     new LlamaERC721TokenHolderCaster(erc721VotesToken, ILlamaCore(address(CORE)), tokenVotingCasterRole,
+//     vm.expectRevert(abi.encodeWithSelector(LlamaTokenCaster.InvalidMinApprovalPct.selector, uint256(10_001)));
+//     new LlamaERC20TokenCaster(erc20VotesToken, ILlamaCore(address(CORE)), tokenVotingCasterRole,
 // uint256(10_001),
 // uint256(1));
 //   }
 
 //   function test_RevertsIf_InvalidMinDisapprovalPct() public {
-//     vm.expectRevert(abi.encodeWithSelector(LlamaTokenHolderCaster.InvalidMinDisapprovalPct.selector, uint256(0)));
-//     new LlamaERC721TokenHolderCaster(erc721VotesToken, ILlamaCore(address(CORE)), tokenVotingCasterRole, uint256(1),
+//     vm.expectRevert(abi.encodeWithSelector(LlamaTokenCaster.InvalidMinDisapprovalPct.selector, uint256(0)));
+//     new LlamaERC20TokenCaster(erc20VotesToken, ILlamaCore(address(CORE)), tokenVotingCasterRole, uint256(1),
 // uint256(0));
-//     vm.expectRevert(abi.encodeWithSelector(LlamaTokenHolderCaster.InvalidMinDisapprovalPct.selector,
+//     vm.expectRevert(abi.encodeWithSelector(LlamaTokenCaster.InvalidMinDisapprovalPct.selector,
 // uint256(10_001)));
-//     new LlamaERC721TokenHolderCaster(erc721VotesToken, ILlamaCore(address(CORE)), tokenVotingCasterRole, uint256(1),
+//     new LlamaERC20TokenCaster(erc20VotesToken, ILlamaCore(address(CORE)), tokenVotingCasterRole, uint256(1),
 // uint256(10_001));
 //   }
 
 //   function test_ProperlySetsConstructorArguments() public {
-//     erc721VotesToken.mint(address(this), 1_000_000e18); // we use erc721VotesToken because IVotesToken is an
-// interface
+//     erc20VotesToken.mint(address(this), 1_000_000e18); // we use erc20VotesToken because IVotesToken is an interface
 //     // without the `mint` function
 
-//     llamaERC721TokenHolderCaster = new LlamaERC721TokenHolderCaster(
-//       erc721VotesToken, ILlamaCore(address(CORE)), tokenVotingCasterRole, DEFAULT_APPROVAL_THRESHOLD,
+//     llamaERC20TokenCaster = new LlamaERC20TokenCaster(
+//       erc20VotesToken, ILlamaCore(address(CORE)), tokenVotingCasterRole, DEFAULT_APPROVAL_THRESHOLD,
 // DEFAULT_APPROVAL_THRESHOLD
 //     );
 
-//     assertEq(address(llamaERC721TokenHolderCaster.LLAMA_CORE()), address(CORE));
-//     assertEq(address(llamaERC721TokenHolderCaster.TOKEN()), address(erc721VotesToken));
-//     assertEq(llamaERC721TokenHolderCaster.ROLE(), tokenVotingCasterRole);
-//     assertEq(llamaERC721TokenHolderCaster.MIN_APPROVAL_PCT(), DEFAULT_APPROVAL_THRESHOLD);
-//     assertEq(llamaERC721TokenHolderCaster.MIN_DISAPPROVAL_PCT(), DEFAULT_APPROVAL_THRESHOLD);
+//     assertEq(address(llamaERC20TokenCaster.LLAMA_CORE()), address(CORE));
+//     assertEq(address(llamaERC20TokenCaster.TOKEN()), address(erc20VotesToken));
+//     assertEq(llamaERC20TokenCaster.ROLE(), tokenVotingCasterRole);
+//     assertEq(llamaERC20TokenCaster.MIN_APPROVAL_PCT(), DEFAULT_APPROVAL_THRESHOLD);
+//     assertEq(llamaERC20TokenCaster.MIN_DISAPPROVAL_PCT(), DEFAULT_APPROVAL_THRESHOLD);
 //   }
 // }
 
-contract CastApproval is LlamaERC721TokenHolderCasterTest {
+contract CastApproval is LlamaERC20TokenCasterTest {
   function test_RevertsIf_ActionInfoMismatch(ActionInfo memory notActionInfo) public {
     vm.assume(notActionInfo.id != actionInfo.id);
     vm.expectRevert();
-    llamaERC721TokenHolderCaster.castApproval(notActionInfo, 1, "");
+    llamaERC20TokenCaster.castApproval(notActionInfo, 1, "");
   }
 
   function test_RevertsIf_ApprovalNotEnabled() public {
-    LlamaERC721TokenHolderCaster casterWithWrongRole = LlamaERC721TokenHolderCaster(
+    LlamaERC20TokenCaster casterWithWrongRole = LlamaERC20TokenCaster(
       Clones.cloneDeterministic(
-        address(llamaERC721TokenHolderCasterLogic), keccak256(abi.encodePacked(address(erc721VotesToken), msg.sender))
+        address(llamaERC20TokenCasterLogic), keccak256(abi.encodePacked(address(erc20VotesToken), msg.sender))
       )
     );
-    casterWithWrongRole.initialize(
-      erc721VotesToken, CORE, madeUpRole, ERC721_MIN_APPROVAL_PCT, ERC721_MIN_DISAPPROVAL_PCT
-    );
+    casterWithWrongRole.initialize(erc20VotesToken, CORE, madeUpRole, ERC20_MIN_APPROVAL_PCT, ERC20_MIN_DISAPPROVAL_PCT);
 
     vm.expectRevert(abi.encodeWithSelector(ILlamaRelativeStrategyBase.InvalidRole.selector, tokenVotingCasterRole));
     casterWithWrongRole.castApproval(actionInfo, 1, "");
@@ -178,33 +174,33 @@ contract CastApproval is LlamaERC721TokenHolderCasterTest {
 
   function test_RevertsIf_ActionNotActive() public {
     vm.warp(block.timestamp + 1 days + 1);
-    vm.expectRevert(LlamaTokenHolderCaster.ActionNotActive.selector);
-    llamaERC721TokenHolderCaster.castApproval(actionInfo, 1, "");
+    vm.expectRevert(LlamaTokenCaster.ActionNotActive.selector);
+    llamaERC20TokenCaster.castApproval(actionInfo, 1, "");
   }
 
   function test_RevertsIf_AlreadyCastApproval() public {
     vm.startPrank(tokenHolder1);
-    llamaERC721TokenHolderCaster.castApproval(actionInfo, 1, "");
+    llamaERC20TokenCaster.castApproval(actionInfo, 1, "");
 
-    vm.expectRevert(LlamaTokenHolderCaster.AlreadyCastApproval.selector);
-    llamaERC721TokenHolderCaster.castApproval(actionInfo, 1, "");
+    vm.expectRevert(LlamaTokenCaster.AlreadyCastApproval.selector);
+    llamaERC20TokenCaster.castApproval(actionInfo, 1, "");
   }
 
   function test_RevertsIf_InvalidSupport() public {
-    vm.expectRevert(abi.encodeWithSelector(LlamaTokenHolderCaster.InvalidSupport.selector, uint8(3)));
-    llamaERC721TokenHolderCaster.castApproval(actionInfo, 3, "");
+    vm.expectRevert(abi.encodeWithSelector(LlamaTokenCaster.InvalidSupport.selector, uint8(3)));
+    llamaERC20TokenCaster.castApproval(actionInfo, 3, "");
   }
 
   function test_RevertsIf_CastingPeriodOver() public {
     vm.warp(block.timestamp + ((1 days * TWO_THIRDS_IN_BPS) / ONE_HUNDRED_IN_BPS) + 1); // 2/3 of the approval period
-    vm.expectRevert(LlamaTokenHolderCaster.CastingPeriodOver.selector);
+    vm.expectRevert(LlamaTokenCaster.CastingPeriodOver.selector);
     vm.prank(tokenHolder1);
-    llamaERC721TokenHolderCaster.castApproval(actionInfo, 1, "");
+    llamaERC20TokenCaster.castApproval(actionInfo, 1, "");
   }
 
   function test_RevertsIf_InsufficientBalance() public {
-    vm.expectRevert(abi.encodeWithSelector(LlamaTokenHolderCaster.InsufficientBalance.selector, 0));
-    llamaERC721TokenHolderCaster.castApproval(actionInfo, 1, "");
+    vm.expectRevert(abi.encodeWithSelector(LlamaTokenCaster.InsufficientBalance.selector, 0));
+    llamaERC20TokenCaster.castApproval(actionInfo, 1, "");
   }
 
   function test_CastsApprovalCorrectly(uint8 support) public {
@@ -215,11 +211,11 @@ contract CastApproval is LlamaERC721TokenHolderCasterTest {
       tokenHolder1,
       tokenVotingCasterRole,
       support,
-      erc721VotesToken.getPastVotes(tokenHolder1, block.timestamp - 1),
+      erc20VotesToken.getPastVotes(tokenHolder1, block.timestamp - 1),
       ""
     );
     vm.prank(tokenHolder1);
-    llamaERC721TokenHolderCaster.castApproval(actionInfo, support, "");
+    llamaERC20TokenCaster.castApproval(actionInfo, support, "");
   }
 
   function test_CastsApprovalCorrectly_WithReason() public {
@@ -229,17 +225,17 @@ contract CastApproval is LlamaERC721TokenHolderCasterTest {
       tokenHolder1,
       tokenVotingCasterRole,
       1,
-      erc721VotesToken.getPastVotes(tokenHolder1, erc721VotesToken.clock() - 1),
+      erc20VotesToken.getPastVotes(tokenHolder1, erc20VotesToken.clock() - 1),
       "reason"
     );
     vm.prank(tokenHolder1);
-    llamaERC721TokenHolderCaster.castApproval(actionInfo, 1, "reason");
+    llamaERC20TokenCaster.castApproval(actionInfo, 1, "reason");
   }
 }
 
-contract CastApprovalBySig is LlamaERC721TokenHolderCasterTest {
+contract CastApprovalBySig is LlamaERC20TokenCasterTest {
   function setUp() public virtual override {
-    LlamaERC721TokenHolderCasterTest.setUp();
+    LlamaERC20TokenCasterTest.setUp();
   }
 
   function createOffchainSignature(ActionInfo memory _actionInfo, uint256 privateKey)
@@ -259,7 +255,7 @@ contract CastApprovalBySig is LlamaERC721TokenHolderCasterTest {
   }
 
   function castApprovalBySig(ActionInfo memory _actionInfo, uint8 support, uint8 v, bytes32 r, bytes32 s) internal {
-    llamaERC721TokenHolderCaster.castApprovalBySig(tokenHolder1, support, _actionInfo, "", v, r, s);
+    llamaERC20TokenCaster.castApprovalBySig(tokenHolder1, support, _actionInfo, "", v, r, s);
   }
 
   function test_CastsApprovalBySig() public {
@@ -271,7 +267,7 @@ contract CastApprovalBySig is LlamaERC721TokenHolderCasterTest {
       tokenHolder1,
       tokenVotingCasterRole,
       1,
-      erc721VotesToken.getPastVotes(tokenHolder1, block.timestamp - 1),
+      erc20VotesToken.getPastVotes(tokenHolder1, block.timestamp - 1),
       ""
     );
 
@@ -281,9 +277,9 @@ contract CastApprovalBySig is LlamaERC721TokenHolderCasterTest {
   function test_CheckNonceIncrements() public {
     (uint8 v, bytes32 r, bytes32 s) = createOffchainSignature(actionInfo, tokenHolder1PrivateKey);
 
-    assertEq(llamaERC721TokenHolderCaster.nonces(tokenHolder1, LlamaTokenHolderCaster.castApprovalBySig.selector), 0);
+    assertEq(llamaERC20TokenCaster.nonces(tokenHolder1, LlamaTokenCaster.castApprovalBySig.selector), 0);
     castApprovalBySig(actionInfo, 1, v, r, s);
-    assertEq(llamaERC721TokenHolderCaster.nonces(tokenHolder1, LlamaTokenHolderCaster.castApprovalBySig.selector), 1);
+    assertEq(llamaERC20TokenCaster.nonces(tokenHolder1, LlamaTokenCaster.castApprovalBySig.selector), 1);
   }
 
   function test_OperationCannotBeReplayed() public {
@@ -291,7 +287,7 @@ contract CastApprovalBySig is LlamaERC721TokenHolderCasterTest {
     castApprovalBySig(actionInfo, 1, v, r, s);
     // Invalid Signature error since the recovered signer address during the second call is not the same as
     // erc20VotesTokenholder since nonce has increased.
-    vm.expectRevert(LlamaTokenHolderCaster.InvalidSignature.selector);
+    vm.expectRevert(LlamaTokenCaster.InvalidSignature.selector);
     castApprovalBySig(actionInfo, 1, v, r, s);
   }
 
@@ -316,7 +312,7 @@ contract CastApprovalBySig is LlamaERC721TokenHolderCasterTest {
     (uint8 v, bytes32 r, bytes32 s) = createOffchainSignature(actionInfo, tokenHolder1PrivateKey);
 
     vm.prank(tokenHolder1);
-    llamaERC721TokenHolderCaster.incrementNonce(ILlamaCore.castApprovalBySig.selector);
+    llamaERC20TokenCaster.incrementNonce(ILlamaCore.castApprovalBySig.selector);
 
     // Invalid Signature error since the recovered signer address during the call is not the same as
     // erc20VotesTokenholder since nonce has increased.
@@ -325,33 +321,31 @@ contract CastApprovalBySig is LlamaERC721TokenHolderCasterTest {
   }
 }
 
-contract CastDisapproval is LlamaERC721TokenHolderCasterTest {
+contract CastDisapproval is LlamaERC20TokenCasterTest {
   function setUp() public virtual override {
-    LlamaERC721TokenHolderCasterTest.setUp();
+    LlamaERC20TokenCasterTest.setUp();
 
     castApprovalsFor();
 
     vm.warp(block.timestamp + (1 days * TWO_THIRDS_IN_BPS) / ONE_HUNDRED_IN_BPS);
 
     vm.prank(tokenHolder1);
-    llamaERC721TokenHolderCaster.submitApprovals(actionInfo);
+    llamaERC20TokenCaster.submitApprovals(actionInfo);
   }
 
   function test_RevertsIf_ActionInfoMismatch(ActionInfo memory notActionInfo) public {
     vm.assume(notActionInfo.id != actionInfo.id);
     vm.expectRevert();
-    llamaERC721TokenHolderCaster.castDisapproval(notActionInfo, tokenVotingCasterRole, "");
+    llamaERC20TokenCaster.castDisapproval(notActionInfo, tokenVotingCasterRole, "");
   }
 
   function test_RevertsIf_DisapprovalNotEnabled() public {
-    LlamaERC721TokenHolderCaster casterWithWrongRole = LlamaERC721TokenHolderCaster(
+    LlamaERC20TokenCaster casterWithWrongRole = LlamaERC20TokenCaster(
       Clones.cloneDeterministic(
-        address(llamaERC721TokenHolderCasterLogic), keccak256(abi.encodePacked(address(erc721VotesToken), msg.sender))
+        address(llamaERC20TokenCasterLogic), keccak256(abi.encodePacked(address(erc20VotesToken), msg.sender))
       )
     );
-    casterWithWrongRole.initialize(
-      erc721VotesToken, CORE, madeUpRole, ERC721_MIN_APPROVAL_PCT, ERC721_MIN_DISAPPROVAL_PCT
-    );
+    casterWithWrongRole.initialize(erc20VotesToken, CORE, madeUpRole, ERC20_MIN_APPROVAL_PCT, ERC20_MIN_DISAPPROVAL_PCT);
 
     vm.expectRevert(abi.encodeWithSelector(ILlamaRelativeStrategyBase.InvalidRole.selector, tokenVotingCasterRole));
     casterWithWrongRole.castDisapproval(actionInfo, madeUpRole, "");
@@ -359,27 +353,27 @@ contract CastDisapproval is LlamaERC721TokenHolderCasterTest {
 
   function test_RevertsIf_AlreadyCastApproval() public {
     vm.startPrank(tokenHolder1);
-    llamaERC721TokenHolderCaster.castDisapproval(actionInfo, 1, "");
+    llamaERC20TokenCaster.castDisapproval(actionInfo, 1, "");
 
-    vm.expectRevert(LlamaTokenHolderCaster.AlreadyCastDisapproval.selector);
-    llamaERC721TokenHolderCaster.castDisapproval(actionInfo, 1, "");
+    vm.expectRevert(LlamaTokenCaster.AlreadyCastDisapproval.selector);
+    llamaERC20TokenCaster.castDisapproval(actionInfo, 1, "");
   }
 
   function test_RevertsIf_InvalidSupport() public {
-    vm.expectRevert(abi.encodeWithSelector(LlamaTokenHolderCaster.InvalidSupport.selector, uint8(3)));
-    llamaERC721TokenHolderCaster.castDisapproval(actionInfo, 3, "");
+    vm.expectRevert(abi.encodeWithSelector(LlamaTokenCaster.InvalidSupport.selector, uint8(3)));
+    llamaERC20TokenCaster.castDisapproval(actionInfo, 3, "");
   }
 
   function test_RevertsIf_CastingPeriodOver() public {
     // TODO why do we need to add 2 here
     vm.warp(block.timestamp + 2 + (1 days * TWO_THIRDS_IN_BPS) / ONE_HUNDRED_IN_BPS); // 2/3 of the approval period
-    vm.expectRevert(LlamaTokenHolderCaster.CastingPeriodOver.selector);
-    llamaERC721TokenHolderCaster.castDisapproval(actionInfo, 1, "");
+    vm.expectRevert(LlamaTokenCaster.CastingPeriodOver.selector);
+    llamaERC20TokenCaster.castDisapproval(actionInfo, 1, "");
   }
 
   function test_RevertsIf_InsufficientBalance() public {
-    vm.expectRevert(abi.encodeWithSelector(LlamaTokenHolderCaster.InsufficientBalance.selector, 0));
-    llamaERC721TokenHolderCaster.castDisapproval(actionInfo, 1, "");
+    vm.expectRevert(abi.encodeWithSelector(LlamaTokenCaster.InsufficientBalance.selector, 0));
+    llamaERC20TokenCaster.castDisapproval(actionInfo, 1, "");
   }
 
   function test_CastsDisapprovalCorrectly(uint8 support) public {
@@ -390,11 +384,11 @@ contract CastDisapproval is LlamaERC721TokenHolderCasterTest {
       tokenHolder1,
       tokenVotingCasterRole,
       support,
-      erc721VotesToken.getPastVotes(tokenHolder1, block.timestamp - 1),
+      erc20VotesToken.getPastVotes(tokenHolder1, block.timestamp - 1),
       ""
     );
     vm.prank(tokenHolder1);
-    llamaERC721TokenHolderCaster.castDisapproval(actionInfo, support, "");
+    llamaERC20TokenCaster.castDisapproval(actionInfo, support, "");
   }
 
   function test_CastsDisapprovalCorrectly_WithReason() public {
@@ -404,24 +398,24 @@ contract CastDisapproval is LlamaERC721TokenHolderCasterTest {
       tokenHolder1,
       tokenVotingCasterRole,
       1,
-      erc721VotesToken.getPastVotes(tokenHolder1, erc721VotesToken.clock() - 1),
+      erc20VotesToken.getPastVotes(tokenHolder1, erc20VotesToken.clock() - 1),
       "reason"
     );
     vm.prank(tokenHolder1);
-    llamaERC721TokenHolderCaster.castDisapproval(actionInfo, 1, "reason");
+    llamaERC20TokenCaster.castDisapproval(actionInfo, 1, "reason");
   }
 }
 
-contract CastDisapprovalBySig is LlamaERC721TokenHolderCasterTest {
+contract CastDisapprovalBySig is LlamaERC20TokenCasterTest {
   function setUp() public virtual override {
-    LlamaERC721TokenHolderCasterTest.setUp();
+    LlamaERC20TokenCasterTest.setUp();
 
     castApprovalsFor();
 
     vm.warp(block.timestamp + (1 days * TWO_THIRDS_IN_BPS) / ONE_HUNDRED_IN_BPS);
 
     vm.prank(tokenHolder1);
-    llamaERC721TokenHolderCaster.submitApprovals(actionInfo);
+    llamaERC20TokenCaster.submitApprovals(actionInfo);
   }
 
   function createOffchainSignature(ActionInfo memory _actionInfo, uint256 privateKey)
@@ -441,7 +435,7 @@ contract CastDisapprovalBySig is LlamaERC721TokenHolderCasterTest {
   }
 
   function castDisapprovalBySig(ActionInfo memory _actionInfo, uint8 v, bytes32 r, bytes32 s) internal {
-    llamaERC721TokenHolderCaster.castDisapprovalBySig(tokenHolder1, 1, _actionInfo, "", v, r, s);
+    llamaERC20TokenCaster.castDisapprovalBySig(tokenHolder1, 1, _actionInfo, "", v, r, s);
   }
 
   function test_CastsDisapprovalBySig() public {
@@ -453,7 +447,7 @@ contract CastDisapprovalBySig is LlamaERC721TokenHolderCasterTest {
       tokenHolder1,
       tokenVotingCasterRole,
       1,
-      erc721VotesToken.getPastVotes(tokenHolder1, erc721VotesToken.clock() - 1),
+      erc20VotesToken.getPastVotes(tokenHolder1, erc20VotesToken.clock() - 1),
       ""
     );
 
@@ -466,9 +460,9 @@ contract CastDisapprovalBySig is LlamaERC721TokenHolderCasterTest {
   function test_CheckNonceIncrements() public {
     (uint8 v, bytes32 r, bytes32 s) = createOffchainSignature(actionInfo, tokenHolder1PrivateKey);
 
-    assertEq(llamaERC721TokenHolderCaster.nonces(tokenHolder1, ILlamaCore.castDisapprovalBySig.selector), 0);
+    assertEq(llamaERC20TokenCaster.nonces(tokenHolder1, ILlamaCore.castDisapprovalBySig.selector), 0);
     castDisapprovalBySig(actionInfo, v, r, s);
-    assertEq(llamaERC721TokenHolderCaster.nonces(tokenHolder1, ILlamaCore.castDisapprovalBySig.selector), 1);
+    assertEq(llamaERC20TokenCaster.nonces(tokenHolder1, ILlamaCore.castDisapprovalBySig.selector), 1);
   }
 
   function test_OperationCannotBeReplayed() public {
@@ -503,7 +497,7 @@ contract CastDisapprovalBySig is LlamaERC721TokenHolderCasterTest {
     (uint8 v, bytes32 r, bytes32 s) = createOffchainSignature(actionInfo, tokenHolder1PrivateKey);
 
     vm.prank(tokenHolder1);
-    llamaERC721TokenHolderCaster.incrementNonce(ILlamaCore.castDisapprovalBySig.selector);
+    llamaERC20TokenCaster.incrementNonce(ILlamaCore.castDisapprovalBySig.selector);
 
     // Invalid Signature error since the recovered signer address during the second call is not the same as policyholder
     // since nonce has increased.
@@ -521,7 +515,7 @@ contract CastDisapprovalBySig is LlamaERC721TokenHolderCasterTest {
       tokenHolder1,
       tokenVotingCasterRole,
       1,
-      erc721VotesToken.getPastVotes(tokenHolder1, erc721VotesToken.clock() - 1),
+      erc20VotesToken.getPastVotes(tokenHolder1, erc20VotesToken.clock() - 1),
       ""
     );
     castDisapprovalBySig(actionInfo, v, r, s);
@@ -529,11 +523,11 @@ contract CastDisapprovalBySig is LlamaERC721TokenHolderCasterTest {
 
     // Second disapproval.
     vm.prank(tokenHolder2);
-    llamaERC721TokenHolderCaster.castDisapproval(actionInfo, 1, "");
+    llamaERC20TokenCaster.castDisapproval(actionInfo, 1, "");
 
     vm.warp(block.timestamp + 1 + (1 days * TWO_THIRDS_IN_BPS) / ONE_HUNDRED_IN_BPS);
 
-    llamaERC721TokenHolderCaster.submitDisapprovals(actionInfo);
+    llamaERC20TokenCaster.submitDisapprovals(actionInfo);
 
     // Assertions.
     ActionState state = ActionState(CORE.getActionState(actionInfo));
@@ -544,9 +538,9 @@ contract CastDisapprovalBySig is LlamaERC721TokenHolderCasterTest {
   }
 }
 
-contract SubmitApprovals is LlamaERC721TokenHolderCasterTest {
+contract SubmitApprovals is LlamaERC20TokenCasterTest {
   function setUp() public virtual override {
-    LlamaERC721TokenHolderCasterTest.setUp();
+    LlamaERC20TokenCasterTest.setUp();
 
     castApprovalsFor();
 
@@ -556,88 +550,86 @@ contract SubmitApprovals is LlamaERC721TokenHolderCasterTest {
   function test_RevertsIf_ActionInfoMismatch(ActionInfo memory notActionInfo) public {
     vm.assume(notActionInfo.id != actionInfo.id);
     vm.expectRevert();
-    llamaERC721TokenHolderCaster.submitApprovals(notActionInfo);
+    llamaERC20TokenCaster.submitApprovals(notActionInfo);
   }
 
   function test_RevertsIf_AlreadySubmittedApproval() public {
     vm.startPrank(tokenHolder1);
-    llamaERC721TokenHolderCaster.submitApprovals(actionInfo);
+    llamaERC20TokenCaster.submitApprovals(actionInfo);
 
-    vm.expectRevert(LlamaTokenHolderCaster.AlreadySubmittedApproval.selector);
-    llamaERC721TokenHolderCaster.submitApprovals(actionInfo);
+    vm.expectRevert(LlamaTokenCaster.AlreadySubmittedApproval.selector);
+    llamaERC20TokenCaster.submitApprovals(actionInfo);
   }
 
   function test_RevertsIf_SubmissionPeriodOver() public {
     // TODO why do we need to add 2 here
     vm.warp(block.timestamp + ((1 days * ONE_THIRD_IN_BPS) / ONE_HUNDRED_IN_BPS) + 2); // 1/3 of the approval period
-    vm.expectRevert(LlamaTokenHolderCaster.SubmissionPeriodOver.selector);
-    llamaERC721TokenHolderCaster.submitApprovals(actionInfo);
+    vm.expectRevert(LlamaTokenCaster.SubmissionPeriodOver.selector);
+    llamaERC20TokenCaster.submitApprovals(actionInfo);
   }
 
   function test_RevertsIf_InsufficientApprovals() public {
     actionInfo = _createActionWithTokenVotingStrategy(tokenVotingStrategy);
     vm.warp(block.timestamp + (1 days * TWO_THIRDS_IN_BPS) / ONE_HUNDRED_IN_BPS);
-    vm.expectRevert(abi.encodeWithSelector(LlamaTokenHolderCaster.InsufficientApprovals.selector, 0, 1));
-    llamaERC721TokenHolderCaster.submitApprovals(actionInfo);
+    vm.expectRevert(abi.encodeWithSelector(LlamaTokenCaster.InsufficientApprovals.selector, 0, 75_000e18));
+    llamaERC20TokenCaster.submitApprovals(actionInfo);
   }
 
   function test_RevertsIf_CastingPeriodNotOver() public {
     actionInfo = _createActionWithTokenVotingStrategy(tokenVotingStrategy);
     vm.warp(block.timestamp + (1 days * ONE_THIRD_IN_BPS) / ONE_HUNDRED_IN_BPS); // 1/3 of the approval period
-    vm.expectRevert(LlamaTokenHolderCaster.CantSubmitYet.selector);
-    llamaERC721TokenHolderCaster.submitApprovals(actionInfo);
+    vm.expectRevert(LlamaTokenCaster.CantSubmitYet.selector);
+    llamaERC20TokenCaster.submitApprovals(actionInfo);
   }
 
   function test_RevertsIf_ForDoesNotSurpassAgainst() public {
     actionInfo = _createActionWithTokenVotingStrategy(tokenVotingStrategy);
 
     vm.prank(tokenHolder1);
-    llamaERC721TokenHolderCaster.castApproval(actionInfo, 1, "");
+    llamaERC20TokenCaster.castApproval(actionInfo, 1, "");
     vm.prank(tokenHolder2);
-    llamaERC721TokenHolderCaster.castApproval(actionInfo, 0, "");
+    llamaERC20TokenCaster.castApproval(actionInfo, 0, "");
     vm.prank(tokenHolder3);
-    llamaERC721TokenHolderCaster.castApproval(actionInfo, 0, "");
+    llamaERC20TokenCaster.castApproval(actionInfo, 0, "");
 
     vm.warp(block.timestamp + (1 days * TWO_THIRDS_IN_BPS) / ONE_HUNDRED_IN_BPS);
-    vm.expectRevert(abi.encodeWithSelector(LlamaTokenHolderCaster.ForDoesNotSurpassAgainst.selector, 1, 2));
-    llamaERC721TokenHolderCaster.submitApprovals(actionInfo);
+    vm.expectRevert(abi.encodeWithSelector(LlamaTokenCaster.ForDoesNotSurpassAgainst.selector, 250_000e18, 500_000e18));
+    llamaERC20TokenCaster.submitApprovals(actionInfo);
   }
 
   function test_SubmitsApprovalsCorrectly() public {
     vm.expectEmit();
-    emit ApprovalsSubmitted(actionInfo.id, 3, 0, 0);
-    llamaERC721TokenHolderCaster.submitApprovals(actionInfo);
+    emit ApprovalsSubmitted(actionInfo.id, 750_000e18, 0, 0);
+    llamaERC20TokenCaster.submitApprovals(actionInfo);
   }
 }
 
-contract SubmitDisapprovals is LlamaERC721TokenHolderCasterTest {
+contract SubmitDisapprovals is LlamaERC20TokenCasterTest {
   function setUp() public virtual override {
-    LlamaERC721TokenHolderCasterTest.setUp();
+    LlamaERC20TokenCasterTest.setUp();
 
     castApprovalsFor();
 
     vm.warp(block.timestamp + (1 days * TWO_THIRDS_IN_BPS) / ONE_HUNDRED_IN_BPS);
 
-    llamaERC721TokenHolderCaster.submitApprovals(actionInfo);
+    llamaERC20TokenCaster.submitApprovals(actionInfo);
   }
 
   function test_RevertsIf_ActionInfoMismatch(ActionInfo memory notActionInfo) public {
     vm.warp(block.timestamp + (1 days * TWO_THIRDS_IN_BPS) / ONE_HUNDRED_IN_BPS);
     vm.assume(notActionInfo.id != actionInfo.id);
     vm.expectRevert();
-    llamaERC721TokenHolderCaster.submitDisapprovals(notActionInfo);
+    llamaERC20TokenCaster.submitDisapprovals(notActionInfo);
   }
 
   function test_RevertsIf_DisapprovalNotEnabled() public {
     vm.warp(block.timestamp + (1 days * TWO_THIRDS_IN_BPS) / ONE_HUNDRED_IN_BPS);
-    LlamaERC721TokenHolderCaster casterWithWrongRole = LlamaERC721TokenHolderCaster(
+    LlamaERC20TokenCaster casterWithWrongRole = LlamaERC20TokenCaster(
       Clones.cloneDeterministic(
-        address(llamaERC721TokenHolderCasterLogic), keccak256(abi.encodePacked(address(erc721VotesToken), msg.sender))
+        address(llamaERC20TokenCasterLogic), keccak256(abi.encodePacked(address(erc20VotesToken), msg.sender))
       )
     );
-    casterWithWrongRole.initialize(
-      erc721VotesToken, CORE, madeUpRole, ERC721_MIN_APPROVAL_PCT, ERC721_MIN_DISAPPROVAL_PCT
-    );
+    casterWithWrongRole.initialize(erc20VotesToken, CORE, madeUpRole, ERC20_MIN_APPROVAL_PCT, ERC20_MIN_DISAPPROVAL_PCT);
     vm.expectRevert(abi.encodeWithSelector(ILlamaRelativeStrategyBase.InvalidRole.selector, tokenVotingCasterRole));
     casterWithWrongRole.submitDisapprovals(actionInfo);
   }
@@ -653,49 +645,49 @@ contract SubmitDisapprovals is LlamaERC721TokenHolderCasterTest {
     castDisapprovalsFor();
 
     vm.startPrank(tokenHolder1);
-    llamaERC721TokenHolderCaster.submitDisapprovals(actionInfo);
+    llamaERC20TokenCaster.submitDisapprovals(actionInfo);
 
-    vm.expectRevert(LlamaTokenHolderCaster.AlreadySubmittedDisapproval.selector);
-    llamaERC721TokenHolderCaster.submitDisapprovals(actionInfo);
+    vm.expectRevert(LlamaTokenCaster.AlreadySubmittedDisapproval.selector);
+    llamaERC20TokenCaster.submitDisapprovals(actionInfo);
   }
 
   function test_RevertsIf_SubmissionPeriodOver() public {
     castDisapprovalsFor();
 
     vm.warp(block.timestamp + 1 days);
-    vm.expectRevert(LlamaTokenHolderCaster.SubmissionPeriodOver.selector);
-    llamaERC721TokenHolderCaster.submitDisapprovals(actionInfo);
+    vm.expectRevert(LlamaTokenCaster.SubmissionPeriodOver.selector);
+    llamaERC20TokenCaster.submitDisapprovals(actionInfo);
   }
 
   function test_RevertsIf_InsufficientDisapprovals() public {
     actionInfo = _createActionWithTokenVotingStrategy(tokenVotingStrategy);
     castApprovalsFor();
     vm.warp(block.timestamp + (1 days * TWO_THIRDS_IN_BPS) / ONE_HUNDRED_IN_BPS);
-    llamaERC721TokenHolderCaster.submitApprovals(actionInfo);
+    llamaERC20TokenCaster.submitApprovals(actionInfo);
 
     //TODO why add 1 here
     vm.warp(block.timestamp + 1 + (1 days * TWO_THIRDS_IN_BPS) / ONE_HUNDRED_IN_BPS);
-    vm.expectRevert(abi.encodeWithSelector(LlamaTokenHolderCaster.InsufficientApprovals.selector, 0, 1));
-    llamaERC721TokenHolderCaster.submitDisapprovals(actionInfo);
+    vm.expectRevert(abi.encodeWithSelector(LlamaTokenCaster.InsufficientApprovals.selector, 0, 75_000e18));
+    llamaERC20TokenCaster.submitDisapprovals(actionInfo);
   }
 
   function test_RevertsIf_CastingPeriodNotOver() public {
     vm.warp(block.timestamp + (1 days * 3333) / ONE_HUNDRED_IN_BPS); // 1/3 of the approval period
-    vm.expectRevert(LlamaTokenHolderCaster.CantSubmitYet.selector);
-    llamaERC721TokenHolderCaster.submitDisapprovals(actionInfo);
+    vm.expectRevert(LlamaTokenCaster.CantSubmitYet.selector);
+    llamaERC20TokenCaster.submitDisapprovals(actionInfo);
   }
 
   function test_RevertsIf_ForDoesNotSurpassAgainst() public {
     vm.prank(tokenHolder1);
-    llamaERC721TokenHolderCaster.castDisapproval(actionInfo, 1, "");
+    llamaERC20TokenCaster.castDisapproval(actionInfo, 1, "");
     vm.prank(tokenHolder2);
-    llamaERC721TokenHolderCaster.castDisapproval(actionInfo, 0, "");
+    llamaERC20TokenCaster.castDisapproval(actionInfo, 0, "");
     vm.prank(tokenHolder3);
-    llamaERC721TokenHolderCaster.castDisapproval(actionInfo, 0, "");
+    llamaERC20TokenCaster.castDisapproval(actionInfo, 0, "");
     // TODO why add 1 here?
     vm.warp(block.timestamp + 1 + (1 days * TWO_THIRDS_IN_BPS) / ONE_HUNDRED_IN_BPS);
-    vm.expectRevert(abi.encodeWithSelector(LlamaTokenHolderCaster.ForDoesNotSurpassAgainst.selector, 1, 2));
-    llamaERC721TokenHolderCaster.submitDisapprovals(actionInfo);
+    vm.expectRevert(abi.encodeWithSelector(LlamaTokenCaster.ForDoesNotSurpassAgainst.selector, 250_000e18, 500_000e18));
+    llamaERC20TokenCaster.submitDisapprovals(actionInfo);
   }
 
   function test_SubmitsDisapprovalsCorrectly() public {
@@ -704,7 +696,7 @@ contract SubmitDisapprovals is LlamaERC721TokenHolderCasterTest {
     //TODO why add 1 here?
     vm.warp(block.timestamp + 1 + (1 days * TWO_THIRDS_IN_BPS) / ONE_HUNDRED_IN_BPS);
     vm.expectEmit();
-    emit DisapprovalsSubmitted(actionInfo.id, 3, 0, 0);
-    llamaERC721TokenHolderCaster.submitDisapprovals(actionInfo);
+    emit DisapprovalsSubmitted(actionInfo.id, 750_000e18, 0, 0);
+    llamaERC20TokenCaster.submitDisapprovals(actionInfo);
   }
 }

--- a/test/token-voting/LlamaERC721TokenActionCreator.t.sol
+++ b/test/token-voting/LlamaERC721TokenActionCreator.t.sol
@@ -10,10 +10,10 @@ import {ILlamaCore} from "src/interfaces/ILlamaCore.sol";
 import {ILlamaStrategy} from "src/interfaces/ILlamaStrategy.sol";
 import {ActionState} from "src/lib/Enums.sol";
 import {Action, ActionInfo} from "src/lib/Structs.sol";
-import {LlamaERC721TokenHolderActionCreator} from "src/token-voting/LlamaERC721TokenHolderActionCreator.sol";
-import {LlamaTokenHolderActionCreator} from "src/token-voting/LlamaTokenHolderActionCreator.sol";
+import {LlamaERC721TokenActionCreator} from "src/token-voting/LlamaERC721TokenActionCreator.sol";
+import {LlamaTokenActionCreator} from "src/token-voting/LlamaTokenActionCreator.sol";
 
-contract LlamaERC721TokenHolderActionCreatorTest is LlamaTokenVotingTestSetup, LlamaCoreSigUtils {
+contract LlamaERC721TokenActionCreatorTest is LlamaTokenVotingTestSetup, LlamaCoreSigUtils {
   event ActionCreated(
     uint256 id,
     address indexed creator,
@@ -29,7 +29,7 @@ contract LlamaERC721TokenHolderActionCreatorTest is LlamaTokenVotingTestSetup, L
 
   event ActionThresholdSet(uint256 newThreshold);
 
-  LlamaERC721TokenHolderActionCreator llamaERC721TokenHolderActionCreator;
+  LlamaERC721TokenActionCreator llamaERC721TokenActionCreator;
 
   function setUp() public virtual override {
     LlamaTokenVotingTestSetup.setUp();
@@ -42,7 +42,7 @@ contract LlamaERC721TokenHolderActionCreatorTest is LlamaTokenVotingTestSetup, L
     mineBlock();
 
     // Deploy ERC20 Token Voting Module.
-    (llamaERC721TokenHolderActionCreator,) = _deployERC721TokenVotingModuleAndSetRole();
+    (llamaERC721TokenActionCreator,) = _deployERC721TokenVotingModuleAndSetRole();
 
     // Setting ERC20TokenHolderActionCreator's EIP-712 Domain Hash
     setDomainHash(
@@ -50,23 +50,23 @@ contract LlamaERC721TokenHolderActionCreatorTest is LlamaTokenVotingTestSetup, L
         name: CORE.name(),
         version: "1",
         chainId: block.chainid,
-        verifyingContract: address(llamaERC721TokenHolderActionCreator)
+        verifyingContract: address(llamaERC721TokenActionCreator)
       })
     );
   }
 }
 
-// contract Constructor is LlamaERC721TokenHolderActionCreatorTest {
+// contract Constructor is LlamaERC721TokenActionCreatorTest {
 //   function test_RevertsIf_InvalidLlamaCore() public {
-//     // With invalid LlamaCore instance, LlamaTokenHolderActionCreator.InvalidLlamaCoreAddress is unreachable
+//     // With invalid LlamaCore instance, LlamaTokenActionCreator.InvalidLlamaCoreAddress is unreachable
 //     vm.expectRevert();
-//     new LlamaERC721TokenHolderActionCreator(erc721VotesToken, ILlamaCore(makeAddr("invalid-llama-core")),
+//     new LlamaERC721TokenActionCreator(erc721VotesToken, ILlamaCore(makeAddr("invalid-llama-core")),
 // uint256(0));
 //   }
 
 //   function test_RevertsIf_InvalidTokenAddress() public {
 //     vm.expectRevert(); // will EvmError: Revert vecause totalSupply fn does not exist
-//     new LlamaERC721TokenHolderActionCreator(ERC20Votes(makeAddr("invalid-erc721VotesToken")), CORE, uint256(0));
+//     new LlamaERC721TokenActionCreator(ERC20Votes(makeAddr("invalid-erc721VotesToken")), CORE, uint256(0));
 //   }
 
 //   function test_RevertsIf_CreationThresholdExceedsTotalSupply() public {
@@ -75,8 +75,8 @@ contract LlamaERC721TokenHolderActionCreatorTest is LlamaTokenVotingTestSetup, L
 
 //     vm.warp(block.timestamp + 1);
 
-//     vm.expectRevert(LlamaTokenHolderActionCreator.InvalidCreationThreshold.selector);
-//     new LlamaERC721TokenHolderActionCreator(erc721VotesToken, CORE, 17_000_000_000_000_000_000_000_000);
+//     vm.expectRevert(LlamaTokenActionCreator.InvalidCreationThreshold.selector);
+//     new LlamaERC721TokenActionCreator(erc721VotesToken, CORE, 17_000_000_000_000_000_000_000_000);
 //   }
 
 //   function test_ProperlySetsConstructorArguments() public {
@@ -86,17 +86,17 @@ contract LlamaERC721TokenHolderActionCreatorTest is LlamaTokenVotingTestSetup, L
 
 //     vm.warp(block.timestamp + 1);
 
-//     LlamaERC721TokenHolderActionCreator llamaERC721TokenHolderActionCreator = new
-// LlamaERC721TokenHolderActionCreator(erc721VotesToken,
+//     LlamaERC721TokenActionCreator llamaERC721TokenActionCreator = new
+// LlamaERC721TokenActionCreator(erc721VotesToken,
 // CORE,
 // threshold);
-//     assertEq(address(llamaERC721TokenHolderActionCreator.TOKEN()), address(erc721VotesToken));
-//     assertEq(address(llamaERC721TokenHolderActionCreator.LLAMA_CORE()), address(CORE));
-//     assertEq(llamaERC721TokenHolderActionCreator.creationThreshold(), threshold);
+//     assertEq(address(llamaERC721TokenActionCreator.TOKEN()), address(erc721VotesToken));
+//     assertEq(address(llamaERC721TokenActionCreator.LLAMA_CORE()), address(CORE));
+//     assertEq(llamaERC721TokenActionCreator.creationThreshold(), threshold);
 //   }
 // }
 
-contract CreateAction is LlamaERC721TokenHolderActionCreatorTest {
+contract CreateAction is LlamaERC721TokenActionCreatorTest {
   bytes data = abi.encodeCall(mockProtocol.pause, (true));
 
   function test_RevertsIf_InsufficientBalance() public {
@@ -106,12 +106,12 @@ contract CreateAction is LlamaERC721TokenHolderActionCreatorTest {
 
     mineBlock();
 
-    vm.expectRevert(abi.encodeWithSelector(LlamaTokenHolderActionCreator.InsufficientBalance.selector, 0));
+    vm.expectRevert(abi.encodeWithSelector(LlamaTokenActionCreator.InsufficientBalance.selector, 0));
     vm.prank(notTokenHolder);
-    llamaERC721TokenHolderActionCreator.createAction(STRATEGY, address(mockProtocol), 0, data, "");
+    llamaERC721TokenActionCreator.createAction(STRATEGY, address(mockProtocol), 0, data, "");
   }
 
-  function test_RevertsIf_LlamaTokenHolderActionCreatorDoesNotHavePermission() public {
+  function test_RevertsIf_LlamaTokenActionCreatorDoesNotHavePermission() public {
     erc721VotesToken.mint(tokenHolder1, ERC721_CREATION_THRESHOLD);
     vm.prank(tokenHolder1);
     erc721VotesToken.delegate(tokenHolder1);
@@ -120,12 +120,12 @@ contract CreateAction is LlamaERC721TokenHolderActionCreatorTest {
 
     vm.expectRevert(ILlamaCore.PolicyholderDoesNotHavePermission.selector);
     vm.prank(tokenHolder1);
-    llamaERC721TokenHolderActionCreator.createAction(STRATEGY, address(mockProtocol), 0, data, "");
+    llamaERC721TokenActionCreator.createAction(STRATEGY, address(mockProtocol), 0, data, "");
   }
 
   function test_ProperlyCreatesAction() public {
-    // Assigns Permission to LlamaTokenHolderActionCreator.
-    _setRolePermissionToLlamaTokenHolderActionCreator();
+    // Assigns Permission to LlamaTokenActionCreator.
+    _setRolePermissionToLlamaTokenActionCreator();
 
     // Mint tokens to tokenholder so that they can create action.
     erc721VotesToken.mint(tokenHolder1, ERC721_CREATION_THRESHOLD);
@@ -142,7 +142,7 @@ contract CreateAction is LlamaERC721TokenHolderActionCreatorTest {
       actionCount, address(tokenHolder1), tokenVotingActionCreatorRole, STRATEGY, address(mockProtocol), 0, data, ""
     );
     vm.prank(tokenHolder1);
-    uint256 actionId = llamaERC721TokenHolderActionCreator.createAction(STRATEGY, address(mockProtocol), 0, data, "");
+    uint256 actionId = llamaERC721TokenActionCreator.createAction(STRATEGY, address(mockProtocol), 0, data, "");
 
     Action memory action = CORE.getAction(actionId);
     assertEq(actionId, actionCount);
@@ -150,12 +150,12 @@ contract CreateAction is LlamaERC721TokenHolderActionCreatorTest {
   }
 }
 
-contract CreateActionBySig is LlamaERC721TokenHolderActionCreatorTest {
+contract CreateActionBySig is LlamaERC721TokenActionCreatorTest {
   function setUp() public virtual override {
-    LlamaERC721TokenHolderActionCreatorTest.setUp();
+    LlamaERC721TokenActionCreatorTest.setUp();
 
-    // Assigns Permission to LlamaTokenHolderActionCreator.
-    _setRolePermissionToLlamaTokenHolderActionCreator();
+    // Assigns Permission to LlamaTokenActionCreator.
+    _setRolePermissionToLlamaTokenActionCreator();
 
     // Mint tokens to tokenholder so that they can create action.
     erc721VotesToken.mint(tokenHolder1, ERC721_CREATION_THRESHOLD);
@@ -189,7 +189,7 @@ contract CreateActionBySig is LlamaERC721TokenHolderActionCreatorTest {
   }
 
   function createActionBySig(uint8 v, bytes32 r, bytes32 s) internal returns (uint256 actionId) {
-    actionId = llamaERC721TokenHolderActionCreator.createActionBySig(
+    actionId = llamaERC721TokenActionCreator.createActionBySig(
       tokenHolder1, STRATEGY, address(mockProtocol), 0, abi.encodeCall(mockProtocol.pause, (true)), "", v, r, s
     );
   }
@@ -232,7 +232,7 @@ contract CreateActionBySig is LlamaERC721TokenHolderActionCreatorTest {
       "# Action 0 \n This is my action."
     );
 
-    uint256 actionId = llamaERC721TokenHolderActionCreator.createActionBySig(
+    uint256 actionId = llamaERC721TokenActionCreator.createActionBySig(
       tokenHolder1,
       STRATEGY,
       address(mockProtocol),
@@ -252,15 +252,9 @@ contract CreateActionBySig is LlamaERC721TokenHolderActionCreatorTest {
 
   function test_CheckNonceIncrements() public {
     (uint8 v, bytes32 r, bytes32 s) = createOffchainSignature(tokenHolder1PrivateKey);
-    assertEq(
-      llamaERC721TokenHolderActionCreator.nonces(tokenHolder1, LlamaTokenHolderActionCreator.createActionBySig.selector),
-      0
-    );
+    assertEq(llamaERC721TokenActionCreator.nonces(tokenHolder1, LlamaTokenActionCreator.createActionBySig.selector), 0);
     createActionBySig(v, r, s);
-    assertEq(
-      llamaERC721TokenHolderActionCreator.nonces(tokenHolder1, LlamaTokenHolderActionCreator.createActionBySig.selector),
-      1
-    );
+    assertEq(llamaERC721TokenActionCreator.nonces(tokenHolder1, LlamaTokenActionCreator.createActionBySig.selector), 1);
   }
 
   function test_OperationCannotBeReplayed() public {
@@ -268,7 +262,7 @@ contract CreateActionBySig is LlamaERC721TokenHolderActionCreatorTest {
     createActionBySig(v, r, s);
     // Invalid Signature error since the recovered signer address during the second call is not the same as
     // policyholder since nonce has increased.
-    vm.expectRevert(LlamaTokenHolderActionCreator.InvalidSignature.selector);
+    vm.expectRevert(LlamaTokenActionCreator.InvalidSignature.selector);
     createActionBySig(v, r, s);
   }
 
@@ -277,7 +271,7 @@ contract CreateActionBySig is LlamaERC721TokenHolderActionCreatorTest {
     (uint8 v, bytes32 r, bytes32 s) = createOffchainSignature(randomSignerPrivateKey);
     // Invalid Signature error since the recovered signer address is not the same as the policyholder passed in as
     // parameter.
-    vm.expectRevert(LlamaTokenHolderActionCreator.InvalidSignature.selector);
+    vm.expectRevert(LlamaTokenActionCreator.InvalidSignature.selector);
     createActionBySig(v, r, s);
   }
 
@@ -285,7 +279,7 @@ contract CreateActionBySig is LlamaERC721TokenHolderActionCreatorTest {
     (uint8 v, bytes32 r, bytes32 s) = createOffchainSignature(tokenHolder1PrivateKey);
     // Invalid Signature error since the recovered signer address is zero address due to invalid signature values
     // (v,r,s).
-    vm.expectRevert(LlamaTokenHolderActionCreator.InvalidSignature.selector);
+    vm.expectRevert(LlamaTokenActionCreator.InvalidSignature.selector);
     createActionBySig((v + 1), r, s);
   }
 
@@ -293,24 +287,24 @@ contract CreateActionBySig is LlamaERC721TokenHolderActionCreatorTest {
     (uint8 v, bytes32 r, bytes32 s) = createOffchainSignature(tokenHolder1PrivateKey);
 
     vm.prank(tokenHolder1);
-    llamaERC721TokenHolderActionCreator.incrementNonce(LlamaTokenHolderActionCreator.createActionBySig.selector);
+    llamaERC721TokenActionCreator.incrementNonce(LlamaTokenActionCreator.createActionBySig.selector);
 
     // Invalid Signature error since the recovered signer address during the call is not the same as policyholder
     // since nonce has increased.
-    vm.expectRevert(LlamaTokenHolderActionCreator.InvalidSignature.selector);
+    vm.expectRevert(LlamaTokenActionCreator.InvalidSignature.selector);
     createActionBySig(v, r, s);
   }
 }
 
-contract CancelAction is LlamaERC721TokenHolderActionCreatorTest {
+contract CancelAction is LlamaERC721TokenActionCreatorTest {
   uint256 actionId;
   ActionInfo actionInfo;
 
   function setUp() public virtual override {
-    LlamaERC721TokenHolderActionCreatorTest.setUp();
+    LlamaERC721TokenActionCreatorTest.setUp();
 
-    // Assigns Permission to LlamaTokenHolderActionCreator.
-    _setRolePermissionToLlamaTokenHolderActionCreator();
+    // Assigns Permission to LlamaTokenActionCreator.
+    _setRolePermissionToLlamaTokenActionCreator();
 
     // Mint tokens to tokenholder so that they can create action.
     erc721VotesToken.mint(tokenHolder1, ERC721_CREATION_THRESHOLD);
@@ -323,11 +317,11 @@ contract CancelAction is LlamaERC721TokenHolderActionCreatorTest {
     bytes memory data = abi.encodeCall(mockProtocol.pause, (true));
 
     vm.prank(tokenHolder1);
-    actionId = llamaERC721TokenHolderActionCreator.createAction(STRATEGY, address(mockProtocol), 0, data, "");
+    actionId = llamaERC721TokenActionCreator.createAction(STRATEGY, address(mockProtocol), 0, data, "");
 
     actionInfo = ActionInfo(
       actionId,
-      address(llamaERC721TokenHolderActionCreator),
+      address(llamaERC721TokenActionCreator),
       tokenVotingActionCreatorRole,
       STRATEGY,
       address(mockProtocol),
@@ -340,26 +334,26 @@ contract CancelAction is LlamaERC721TokenHolderActionCreatorTest {
     vm.expectEmit();
     emit ActionCanceled(actionId, tokenHolder1);
     vm.prank(tokenHolder1);
-    llamaERC721TokenHolderActionCreator.cancelAction(actionInfo);
+    llamaERC721TokenActionCreator.cancelAction(actionInfo);
   }
 
   function test_RevertsIf_CallerIsNotActionCreator(address notCreator) public {
     vm.assume(notCreator != tokenHolder1);
-    vm.expectRevert(LlamaTokenHolderActionCreator.OnlyActionCreator.selector);
+    vm.expectRevert(LlamaTokenActionCreator.OnlyActionCreator.selector);
     vm.prank(notCreator);
-    llamaERC721TokenHolderActionCreator.cancelAction(actionInfo);
+    llamaERC721TokenActionCreator.cancelAction(actionInfo);
   }
 }
 
-contract CancelActionBySig is LlamaERC721TokenHolderActionCreatorTest {
+contract CancelActionBySig is LlamaERC721TokenActionCreatorTest {
   uint256 actionId;
   ActionInfo actionInfo;
 
   function setUp() public virtual override {
-    LlamaERC721TokenHolderActionCreatorTest.setUp();
+    LlamaERC721TokenActionCreatorTest.setUp();
 
-    // Assigns Permission to LlamaTokenHolderActionCreator.
-    _setRolePermissionToLlamaTokenHolderActionCreator();
+    // Assigns Permission to LlamaTokenActionCreator.
+    _setRolePermissionToLlamaTokenActionCreator();
 
     // Mint tokens to tokenholder so that they can create action.
     erc721VotesToken.mint(tokenHolder1, ERC721_CREATION_THRESHOLD);
@@ -372,11 +366,11 @@ contract CancelActionBySig is LlamaERC721TokenHolderActionCreatorTest {
     bytes memory data = abi.encodeCall(mockProtocol.pause, (true));
 
     vm.prank(tokenHolder1);
-    actionId = llamaERC721TokenHolderActionCreator.createAction(STRATEGY, address(mockProtocol), 0, data, "");
+    actionId = llamaERC721TokenActionCreator.createAction(STRATEGY, address(mockProtocol), 0, data, "");
 
     actionInfo = ActionInfo(
       actionId,
-      address(llamaERC721TokenHolderActionCreator),
+      address(llamaERC721TokenActionCreator),
       tokenVotingActionCreatorRole,
       STRATEGY,
       address(mockProtocol),
@@ -393,16 +387,14 @@ contract CancelActionBySig is LlamaERC721TokenHolderActionCreatorTest {
     LlamaCoreSigUtils.CancelAction memory cancelAction = LlamaCoreSigUtils.CancelAction({
       tokenHolder: tokenHolder1,
       actionInfo: _actionInfo,
-      nonce: llamaERC721TokenHolderActionCreator.nonces(
-        tokenHolder1, LlamaTokenHolderActionCreator.cancelActionBySig.selector
-        )
+      nonce: llamaERC721TokenActionCreator.nonces(tokenHolder1, LlamaTokenActionCreator.cancelActionBySig.selector)
     });
     bytes32 digest = getCancelActionTypedDataHash(cancelAction);
     (v, r, s) = vm.sign(privateKey, digest);
   }
 
   function cancelActionBySig(ActionInfo memory _actionInfo, uint8 v, bytes32 r, bytes32 s) internal {
-    llamaERC721TokenHolderActionCreator.cancelActionBySig(tokenHolder1, _actionInfo, v, r, s);
+    llamaERC721TokenActionCreator.cancelActionBySig(tokenHolder1, _actionInfo, v, r, s);
   }
 
   function test_CancelActionBySig() public {
@@ -420,15 +412,9 @@ contract CancelActionBySig is LlamaERC721TokenHolderActionCreatorTest {
   function test_CheckNonceIncrements() public {
     (uint8 v, bytes32 r, bytes32 s) = createOffchainSignature(actionInfo, tokenHolder1PrivateKey);
 
-    assertEq(
-      llamaERC721TokenHolderActionCreator.nonces(tokenHolder1, LlamaTokenHolderActionCreator.cancelActionBySig.selector),
-      0
-    );
+    assertEq(llamaERC721TokenActionCreator.nonces(tokenHolder1, LlamaTokenActionCreator.cancelActionBySig.selector), 0);
     cancelActionBySig(actionInfo, v, r, s);
-    assertEq(
-      llamaERC721TokenHolderActionCreator.nonces(tokenHolder1, LlamaTokenHolderActionCreator.cancelActionBySig.selector),
-      1
-    );
+    assertEq(llamaERC721TokenActionCreator.nonces(tokenHolder1, LlamaTokenActionCreator.cancelActionBySig.selector), 1);
   }
 
   function test_OperationCannotBeReplayed() public {
@@ -436,7 +422,7 @@ contract CancelActionBySig is LlamaERC721TokenHolderActionCreatorTest {
     cancelActionBySig(actionInfo, v, r, s);
     // Invalid Signature error since the recovered signer address during the second call is not the same as policyholder
     // since nonce has increased.
-    vm.expectRevert(LlamaTokenHolderActionCreator.InvalidSignature.selector);
+    vm.expectRevert(LlamaTokenActionCreator.InvalidSignature.selector);
     cancelActionBySig(actionInfo, v, r, s);
   }
 
@@ -445,7 +431,7 @@ contract CancelActionBySig is LlamaERC721TokenHolderActionCreatorTest {
     (uint8 v, bytes32 r, bytes32 s) = createOffchainSignature(actionInfo, randomSignerPrivateKey);
     // Invalid Signature error since the recovered signer address is not the same as the policyholder passed in as
     // parameter.
-    vm.expectRevert(LlamaTokenHolderActionCreator.InvalidSignature.selector);
+    vm.expectRevert(LlamaTokenActionCreator.InvalidSignature.selector);
     cancelActionBySig(actionInfo, v, r, s);
   }
 
@@ -453,7 +439,7 @@ contract CancelActionBySig is LlamaERC721TokenHolderActionCreatorTest {
     (uint8 v, bytes32 r, bytes32 s) = createOffchainSignature(actionInfo, tokenHolder1PrivateKey);
     // Invalid Signature error since the recovered signer address is zero address due to invalid signature values
     // (v,r,s).
-    vm.expectRevert(LlamaTokenHolderActionCreator.InvalidSignature.selector);
+    vm.expectRevert(LlamaTokenActionCreator.InvalidSignature.selector);
     cancelActionBySig(actionInfo, (v + 1), r, s);
   }
 
@@ -461,42 +447,42 @@ contract CancelActionBySig is LlamaERC721TokenHolderActionCreatorTest {
     (uint8 v, bytes32 r, bytes32 s) = createOffchainSignature(actionInfo, tokenHolder1PrivateKey);
 
     vm.prank(tokenHolder1);
-    llamaERC721TokenHolderActionCreator.incrementNonce(LlamaTokenHolderActionCreator.cancelActionBySig.selector);
+    llamaERC721TokenActionCreator.incrementNonce(LlamaTokenActionCreator.cancelActionBySig.selector);
 
     // Invalid Signature error since the recovered signer address during the call is not the same as policyholder
     // since nonce has increased.
-    vm.expectRevert(LlamaTokenHolderActionCreator.InvalidSignature.selector);
+    vm.expectRevert(LlamaTokenActionCreator.InvalidSignature.selector);
     cancelActionBySig(actionInfo, v, r, s);
   }
 }
 
-contract SetActionThreshold is LlamaERC721TokenHolderActionCreatorTest {
+contract SetActionThreshold is LlamaERC721TokenActionCreatorTest {
   function testFuzz_SetsCreationThreshold(uint256 threshold) public {
     threshold = bound(threshold, 0, erc721VotesToken.getPastTotalSupply(block.timestamp - 1));
 
-    assertEq(llamaERC721TokenHolderActionCreator.creationThreshold(), ERC721_CREATION_THRESHOLD);
+    assertEq(llamaERC721TokenActionCreator.creationThreshold(), ERC721_CREATION_THRESHOLD);
 
     vm.expectEmit();
     emit ActionThresholdSet(threshold);
     vm.prank(address(EXECUTOR));
-    llamaERC721TokenHolderActionCreator.setActionThreshold(threshold);
+    llamaERC721TokenActionCreator.setActionThreshold(threshold);
 
-    assertEq(llamaERC721TokenHolderActionCreator.creationThreshold(), threshold);
+    assertEq(llamaERC721TokenActionCreator.creationThreshold(), threshold);
   }
 
   function testFuzz_RevertsIf_CreationThresholdExceedsTotalSupply(uint256 threshold) public {
     vm.assume(threshold > erc721VotesToken.getPastTotalSupply(block.timestamp - 1));
 
-    vm.expectRevert(LlamaTokenHolderActionCreator.InvalidCreationThreshold.selector);
+    vm.expectRevert(LlamaTokenActionCreator.InvalidCreationThreshold.selector);
     vm.prank(address(EXECUTOR));
-    llamaERC721TokenHolderActionCreator.setActionThreshold(threshold);
+    llamaERC721TokenActionCreator.setActionThreshold(threshold);
   }
 
   function testFuzz_RevertsIf_CalledByNotLlamaExecutor(address notLlamaExecutor) public {
     vm.assume(notLlamaExecutor != address(EXECUTOR));
 
-    vm.expectRevert(LlamaTokenHolderActionCreator.OnlyLlamaExecutor.selector);
+    vm.expectRevert(LlamaTokenActionCreator.OnlyLlamaExecutor.selector);
     vm.prank(notLlamaExecutor);
-    llamaERC721TokenHolderActionCreator.setActionThreshold(ERC721_CREATION_THRESHOLD);
+    llamaERC721TokenActionCreator.setActionThreshold(ERC721_CREATION_THRESHOLD);
   }
 }

--- a/test/token-voting/LlamaTokenVotingFactory.t.sol
+++ b/test/token-voting/LlamaTokenVotingFactory.t.sol
@@ -9,19 +9,19 @@ import {LlamaTokenVotingTestSetup} from "test/token-voting/LlamaTokenVotingTestS
 
 import {ActionInfo} from "src/lib/Structs.sol";
 import {ILlamaPolicy} from "src/interfaces/ILlamaPolicy.sol";
-import {LlamaERC20TokenHolderActionCreator} from "src/token-voting/LlamaERC20TokenHolderActionCreator.sol";
-import {LlamaERC20TokenHolderCaster} from "src/token-voting/LlamaERC20TokenHolderCaster.sol";
-import {LlamaERC721TokenHolderActionCreator} from "src/token-voting/LlamaERC721TokenHolderActionCreator.sol";
-import {LlamaERC721TokenHolderCaster} from "src/token-voting/LlamaERC721TokenHolderCaster.sol";
+import {LlamaERC20TokenActionCreator} from "src/token-voting/LlamaERC20TokenActionCreator.sol";
+import {LlamaERC20TokenCaster} from "src/token-voting/LlamaERC20TokenCaster.sol";
+import {LlamaERC721TokenActionCreator} from "src/token-voting/LlamaERC721TokenActionCreator.sol";
+import {LlamaERC721TokenCaster} from "src/token-voting/LlamaERC721TokenCaster.sol";
 import {LlamaTokenVotingFactory} from "src/token-voting/LlamaTokenVotingFactory.sol";
 
 contract LlamaTokenVotingFactoryTest is LlamaTokenVotingTestSetup {
-  event LlamaERC20TokenHolderActionCreatorCreated(address actionCreator, address indexed token);
-  event LlamaERC721TokenHolderActionCreatorCreated(address actionCreator, address indexed token);
-  event LlamaERC20TokenHolderCasterCreated(
+  event LlamaERC20TokenActionCreatorCreated(address actionCreator, address indexed token);
+  event LlamaERC721TokenActionCreatorCreated(address actionCreator, address indexed token);
+  event LlamaERC20TokenCasterCreated(
     address caster, address indexed token, uint256 minApprovalPct, uint256 minDisapprovalPct
   );
-  event LlamaERC721TokenHolderCasterCreated(
+  event LlamaERC721TokenCasterCreated(
     address caster, address indexed token, uint256 minApprovalPct, uint256 minDisapprovalPct
   );
   event ActionThresholdSet(uint256 newThreshold);
@@ -40,26 +40,24 @@ contract LlamaTokenVotingFactoryTest is LlamaTokenVotingTestSetup {
 }
 
 contract Constructor is LlamaTokenVotingFactoryTest {
-  function test_SetsLlamaERC20TokenHolderActionCreatorLogicAddress() public {
+  function test_SetsLlamaERC20TokenActionCreatorLogicAddress() public {
     assertEq(
-      address(tokenVotingFactory.ERC20_TOKENHOLDER_ACTION_CREATOR_LOGIC()),
-      address(llamaERC20TokenHolderActionCreatorLogic)
+      address(tokenVotingFactory.ERC20_TOKENHOLDER_ACTION_CREATOR_LOGIC()), address(llamaERC20TokenActionCreatorLogic)
     );
   }
 
-  function test_SetsLlamaERC20TokenHolderCasterLogicAddress() public {
-    assertEq(address(tokenVotingFactory.ERC20_TOKENHOLDER_CASTER_LOGIC()), address(llamaERC20TokenHolderCasterLogic));
+  function test_SetsLlamaERC20TokenCasterLogicAddress() public {
+    assertEq(address(tokenVotingFactory.ERC20_TOKENHOLDER_CASTER_LOGIC()), address(llamaERC20TokenCasterLogic));
   }
 
-  function test_SetsLlamaERC721TokenHolderActionCreatorLogicAddress() public {
+  function test_SetsLlamaERC721TokenActionCreatorLogicAddress() public {
     assertEq(
-      address(tokenVotingFactory.ERC721_TOKENHOLDER_ACTION_CREATOR_LOGIC()),
-      address(llamaERC721TokenHolderActionCreatorLogic)
+      address(tokenVotingFactory.ERC721_TOKENHOLDER_ACTION_CREATOR_LOGIC()), address(llamaERC721TokenActionCreatorLogic)
     );
   }
 
-  function test_SetsLlamaERC721TokenHolderCasterLogicAddress() public {
-    assertEq(address(tokenVotingFactory.ERC721_TOKENHOLDER_CASTER_LOGIC()), address(llamaERC721TokenHolderCasterLogic));
+  function test_SetsLlamaERC721TokenCasterLogicAddress() public {
+    assertEq(address(tokenVotingFactory.ERC721_TOKENHOLDER_CASTER_LOGIC()), address(llamaERC721TokenCasterLogic));
   }
 }
 
@@ -102,16 +100,16 @@ contract DeployTokenVotingModule is LlamaTokenVotingFactoryTest {
     ActionInfo memory actionInfo = _setPermissionCreateApproveAndQueueAction(data);
 
     // Compute addresses of ERC20 Token Voting Module
-    LlamaERC20TokenHolderActionCreator llamaERC20TokenHolderActionCreator = LlamaERC20TokenHolderActionCreator(
+    LlamaERC20TokenActionCreator llamaERC20TokenActionCreator = LlamaERC20TokenActionCreator(
       Clones.predictDeterministicAddress(
-        address(llamaERC20TokenHolderActionCreatorLogic),
+        address(llamaERC20TokenActionCreatorLogic),
         keccak256(abi.encodePacked(address(erc20VotesToken), address(EXECUTOR))), // salt
         address(tokenVotingFactory) // deployer
       )
     );
-    LlamaERC20TokenHolderCaster llamaERC20TokenHolderCaster = LlamaERC20TokenHolderCaster(
+    LlamaERC20TokenCaster llamaERC20TokenCaster = LlamaERC20TokenCaster(
       Clones.predictDeterministicAddress(
-        address(llamaERC20TokenHolderCasterLogic),
+        address(llamaERC20TokenCasterLogic),
         keccak256(abi.encodePacked(address(erc20VotesToken), address(EXECUTOR))), // salt
         address(tokenVotingFactory) // deployer
       )
@@ -121,24 +119,22 @@ contract DeployTokenVotingModule is LlamaTokenVotingFactoryTest {
     vm.expectEmit();
     emit ActionThresholdSet(ERC20_CREATION_THRESHOLD);
     vm.expectEmit();
-    emit LlamaERC20TokenHolderActionCreatorCreated(
-      address(llamaERC20TokenHolderActionCreator), address(erc20VotesToken)
-    );
+    emit LlamaERC20TokenActionCreatorCreated(address(llamaERC20TokenActionCreator), address(erc20VotesToken));
     vm.expectEmit();
-    emit LlamaERC20TokenHolderCasterCreated(
-      address(llamaERC20TokenHolderCaster), address(erc20VotesToken), ERC20_MIN_APPROVAL_PCT, ERC20_MIN_DISAPPROVAL_PCT
+    emit LlamaERC20TokenCasterCreated(
+      address(llamaERC20TokenCaster), address(erc20VotesToken), ERC20_MIN_APPROVAL_PCT, ERC20_MIN_DISAPPROVAL_PCT
     );
     CORE.executeAction(actionInfo);
 
-    assertEq(address(llamaERC20TokenHolderActionCreator.token()), address(erc20VotesToken));
-    assertEq(address(llamaERC20TokenHolderActionCreator.llamaCore()), address(CORE));
-    assertEq(llamaERC20TokenHolderActionCreator.role(), tokenVotingActionCreatorRole);
-    assertEq(llamaERC20TokenHolderActionCreator.creationThreshold(), ERC20_CREATION_THRESHOLD);
-    assertEq(address(llamaERC20TokenHolderCaster.token()), address(erc20VotesToken));
-    assertEq(address(llamaERC20TokenHolderCaster.llamaCore()), address(CORE));
-    assertEq(llamaERC20TokenHolderCaster.role(), tokenVotingCasterRole);
-    assertEq(llamaERC20TokenHolderCaster.minApprovalPct(), ERC20_MIN_APPROVAL_PCT);
-    assertEq(llamaERC20TokenHolderCaster.minDisapprovalPct(), ERC20_MIN_DISAPPROVAL_PCT);
+    assertEq(address(llamaERC20TokenActionCreator.token()), address(erc20VotesToken));
+    assertEq(address(llamaERC20TokenActionCreator.llamaCore()), address(CORE));
+    assertEq(llamaERC20TokenActionCreator.role(), tokenVotingActionCreatorRole);
+    assertEq(llamaERC20TokenActionCreator.creationThreshold(), ERC20_CREATION_THRESHOLD);
+    assertEq(address(llamaERC20TokenCaster.token()), address(erc20VotesToken));
+    assertEq(address(llamaERC20TokenCaster.llamaCore()), address(CORE));
+    assertEq(llamaERC20TokenCaster.role(), tokenVotingCasterRole);
+    assertEq(llamaERC20TokenCaster.minApprovalPct(), ERC20_MIN_APPROVAL_PCT);
+    assertEq(llamaERC20TokenCaster.minDisapprovalPct(), ERC20_MIN_DISAPPROVAL_PCT);
   }
 
   function test_CanDeployERC721TokenVotingModule() public {
@@ -157,16 +153,16 @@ contract DeployTokenVotingModule is LlamaTokenVotingFactoryTest {
     ActionInfo memory actionInfo = _setPermissionCreateApproveAndQueueAction(data);
 
     // Compute addresses of ERC721 Token Voting Module
-    LlamaERC721TokenHolderActionCreator llamaERC721TokenHolderActionCreator = LlamaERC721TokenHolderActionCreator(
+    LlamaERC721TokenActionCreator llamaERC721TokenActionCreator = LlamaERC721TokenActionCreator(
       Clones.predictDeterministicAddress(
-        address(llamaERC721TokenHolderActionCreatorLogic),
+        address(llamaERC721TokenActionCreatorLogic),
         keccak256(abi.encodePacked(address(erc721VotesToken), address(EXECUTOR))), // salt
         address(tokenVotingFactory) // deployer
       )
     );
-    LlamaERC721TokenHolderCaster llamaERC721TokenHolderCaster = LlamaERC721TokenHolderCaster(
+    LlamaERC721TokenCaster llamaERC721TokenCaster = LlamaERC721TokenCaster(
       Clones.predictDeterministicAddress(
-        address(llamaERC721TokenHolderCasterLogic),
+        address(llamaERC721TokenCasterLogic),
         keccak256(abi.encodePacked(address(erc721VotesToken), address(EXECUTOR))), // salt
         address(tokenVotingFactory) // deployer
       )
@@ -176,44 +172,39 @@ contract DeployTokenVotingModule is LlamaTokenVotingFactoryTest {
     vm.expectEmit();
     emit ActionThresholdSet(ERC721_CREATION_THRESHOLD);
     vm.expectEmit();
-    emit LlamaERC721TokenHolderActionCreatorCreated(
-      address(llamaERC721TokenHolderActionCreator), address(erc721VotesToken)
-    );
+    emit LlamaERC721TokenActionCreatorCreated(address(llamaERC721TokenActionCreator), address(erc721VotesToken));
     vm.expectEmit();
-    emit LlamaERC721TokenHolderCasterCreated(
-      address(llamaERC721TokenHolderCaster),
-      address(erc721VotesToken),
-      ERC721_MIN_APPROVAL_PCT,
-      ERC721_MIN_DISAPPROVAL_PCT
+    emit LlamaERC721TokenCasterCreated(
+      address(llamaERC721TokenCaster), address(erc721VotesToken), ERC721_MIN_APPROVAL_PCT, ERC721_MIN_DISAPPROVAL_PCT
     );
     CORE.executeAction(actionInfo);
 
-    assertEq(address(llamaERC721TokenHolderActionCreator.token()), address(erc721VotesToken));
-    assertEq(address(llamaERC721TokenHolderActionCreator.llamaCore()), address(CORE));
-    assertEq(llamaERC721TokenHolderActionCreator.role(), tokenVotingActionCreatorRole);
-    assertEq(llamaERC721TokenHolderActionCreator.creationThreshold(), ERC721_CREATION_THRESHOLD);
-    assertEq(address(llamaERC721TokenHolderCaster.token()), address(erc721VotesToken));
-    assertEq(address(llamaERC721TokenHolderCaster.llamaCore()), address(CORE));
-    assertEq(llamaERC721TokenHolderCaster.role(), tokenVotingCasterRole);
-    assertEq(llamaERC721TokenHolderCaster.minApprovalPct(), ERC721_MIN_APPROVAL_PCT);
-    assertEq(llamaERC721TokenHolderCaster.minDisapprovalPct(), ERC721_MIN_DISAPPROVAL_PCT);
+    assertEq(address(llamaERC721TokenActionCreator.token()), address(erc721VotesToken));
+    assertEq(address(llamaERC721TokenActionCreator.llamaCore()), address(CORE));
+    assertEq(llamaERC721TokenActionCreator.role(), tokenVotingActionCreatorRole);
+    assertEq(llamaERC721TokenActionCreator.creationThreshold(), ERC721_CREATION_THRESHOLD);
+    assertEq(address(llamaERC721TokenCaster.token()), address(erc721VotesToken));
+    assertEq(address(llamaERC721TokenCaster.llamaCore()), address(CORE));
+    assertEq(llamaERC721TokenCaster.role(), tokenVotingCasterRole);
+    assertEq(llamaERC721TokenCaster.minApprovalPct(), ERC721_MIN_APPROVAL_PCT);
+    assertEq(llamaERC721TokenCaster.minDisapprovalPct(), ERC721_MIN_DISAPPROVAL_PCT);
   }
 
   function test_CanBeDeployedByAnyone(address randomCaller) public {
     vm.assume(randomCaller != address(0));
     vm.deal(randomCaller, 1 ether);
 
-    LlamaERC20TokenHolderActionCreator llamaERC20TokenHolderActionCreator = LlamaERC20TokenHolderActionCreator(
+    LlamaERC20TokenActionCreator llamaERC20TokenActionCreator = LlamaERC20TokenActionCreator(
       Clones.predictDeterministicAddress(
-        address(llamaERC20TokenHolderActionCreatorLogic),
+        address(llamaERC20TokenActionCreatorLogic),
         keccak256(abi.encodePacked(address(erc20VotesToken), randomCaller)), // salt
         address(tokenVotingFactory) // deployer
       )
     );
 
-    LlamaERC20TokenHolderCaster llamaERC20TokenHolderCaster = LlamaERC20TokenHolderCaster(
+    LlamaERC20TokenCaster llamaERC20TokenCaster = LlamaERC20TokenCaster(
       Clones.predictDeterministicAddress(
-        address(llamaERC20TokenHolderCasterLogic),
+        address(llamaERC20TokenCasterLogic),
         keccak256(abi.encodePacked(address(erc20VotesToken), randomCaller)), // salt
         address(tokenVotingFactory) // deployer
       )
@@ -222,12 +213,10 @@ contract DeployTokenVotingModule is LlamaTokenVotingFactoryTest {
     vm.expectEmit();
     emit ActionThresholdSet(ERC20_CREATION_THRESHOLD);
     vm.expectEmit();
-    emit LlamaERC20TokenHolderActionCreatorCreated(
-      address(llamaERC20TokenHolderActionCreator), address(erc20VotesToken)
-    );
+    emit LlamaERC20TokenActionCreatorCreated(address(llamaERC20TokenActionCreator), address(erc20VotesToken));
     vm.expectEmit();
-    emit LlamaERC20TokenHolderCasterCreated(
-      address(llamaERC20TokenHolderCaster), address(erc20VotesToken), ERC20_MIN_APPROVAL_PCT, ERC20_MIN_DISAPPROVAL_PCT
+    emit LlamaERC20TokenCasterCreated(
+      address(llamaERC20TokenCaster), address(erc20VotesToken), ERC20_MIN_APPROVAL_PCT, ERC20_MIN_DISAPPROVAL_PCT
     );
 
     vm.prank(randomCaller);
@@ -242,14 +231,14 @@ contract DeployTokenVotingModule is LlamaTokenVotingFactoryTest {
       ERC20_MIN_DISAPPROVAL_PCT
     );
 
-    assertEq(address(llamaERC20TokenHolderActionCreator.token()), address(erc20VotesToken));
-    assertEq(address(llamaERC20TokenHolderActionCreator.llamaCore()), address(CORE));
-    assertEq(llamaERC20TokenHolderActionCreator.role(), tokenVotingActionCreatorRole);
-    assertEq(llamaERC20TokenHolderActionCreator.creationThreshold(), ERC20_CREATION_THRESHOLD);
-    assertEq(address(llamaERC20TokenHolderCaster.token()), address(erc20VotesToken));
-    assertEq(address(llamaERC20TokenHolderCaster.llamaCore()), address(CORE));
-    assertEq(llamaERC20TokenHolderCaster.role(), tokenVotingCasterRole);
-    assertEq(llamaERC20TokenHolderCaster.minApprovalPct(), ERC20_MIN_APPROVAL_PCT);
-    assertEq(llamaERC20TokenHolderCaster.minDisapprovalPct(), ERC20_MIN_DISAPPROVAL_PCT);
+    assertEq(address(llamaERC20TokenActionCreator.token()), address(erc20VotesToken));
+    assertEq(address(llamaERC20TokenActionCreator.llamaCore()), address(CORE));
+    assertEq(llamaERC20TokenActionCreator.role(), tokenVotingActionCreatorRole);
+    assertEq(llamaERC20TokenActionCreator.creationThreshold(), ERC20_CREATION_THRESHOLD);
+    assertEq(address(llamaERC20TokenCaster.token()), address(erc20VotesToken));
+    assertEq(address(llamaERC20TokenCaster.llamaCore()), address(CORE));
+    assertEq(llamaERC20TokenCaster.role(), tokenVotingCasterRole);
+    assertEq(llamaERC20TokenCaster.minApprovalPct(), ERC20_MIN_APPROVAL_PCT);
+    assertEq(llamaERC20TokenCaster.minDisapprovalPct(), ERC20_MIN_DISAPPROVAL_PCT);
   }
 }

--- a/test/token-voting/LlamaTokenVotingTestSetup.sol
+++ b/test/token-voting/LlamaTokenVotingTestSetup.sol
@@ -15,10 +15,10 @@ import {ILlamaPolicy} from "src/interfaces/ILlamaPolicy.sol";
 import {ILlamaStrategy} from "src/interfaces/ILlamaStrategy.sol";
 import {ILlamaRelativeStrategyBase} from "src/interfaces/ILlamaRelativeStrategyBase.sol";
 import {RoleDescription} from "src/lib/UDVTs.sol";
-import {LlamaERC20TokenHolderActionCreator} from "src/token-voting/LlamaERC20TokenHolderActionCreator.sol";
-import {LlamaERC20TokenHolderCaster} from "src/token-voting/LlamaERC20TokenHolderCaster.sol";
-import {LlamaERC721TokenHolderActionCreator} from "src/token-voting/LlamaERC721TokenHolderActionCreator.sol";
-import {LlamaERC721TokenHolderCaster} from "src/token-voting/LlamaERC721TokenHolderCaster.sol";
+import {LlamaERC20TokenActionCreator} from "src/token-voting/LlamaERC20TokenActionCreator.sol";
+import {LlamaERC20TokenCaster} from "src/token-voting/LlamaERC20TokenCaster.sol";
+import {LlamaERC721TokenActionCreator} from "src/token-voting/LlamaERC721TokenActionCreator.sol";
+import {LlamaERC721TokenCaster} from "src/token-voting/LlamaERC721TokenCaster.sol";
 
 contract LlamaTokenVotingTestSetup is LlamaPeripheryTestSetup, DeployLlamaTokenVotingFactory {
   // Percentages
@@ -91,12 +91,11 @@ contract LlamaTokenVotingTestSetup is LlamaPeripheryTestSetup, DeployLlamaTokenV
 
   function _deployERC20TokenVotingModuleAndSetRole()
     internal
-    returns (LlamaERC20TokenHolderActionCreator, LlamaERC20TokenHolderCaster)
+    returns (LlamaERC20TokenActionCreator, LlamaERC20TokenCaster)
   {
     vm.startPrank(address(EXECUTOR));
     // Deploy Token Voting Module
-    (address llamaERC20TokenHolderActionCreator, address llamaERC20TokenHolderCaster) = tokenVotingFactory
-      .deployTokenVotingModule(
+    (address llamaERC20TokenActionCreator, address llamaERC20TokenCaster) = tokenVotingFactory.deployTokenVotingModule(
       CORE,
       address(erc20VotesToken),
       true,
@@ -108,25 +107,21 @@ contract LlamaTokenVotingTestSetup is LlamaPeripheryTestSetup, DeployLlamaTokenV
     );
     // Assign roles to Token Voting Modules
     POLICY.setRoleHolder(
-      tokenVotingActionCreatorRole, llamaERC20TokenHolderActionCreator, DEFAULT_ROLE_QTY, DEFAULT_ROLE_EXPIRATION
+      tokenVotingActionCreatorRole, llamaERC20TokenActionCreator, DEFAULT_ROLE_QTY, DEFAULT_ROLE_EXPIRATION
     );
-    POLICY.setRoleHolder(tokenVotingCasterRole, llamaERC20TokenHolderCaster, DEFAULT_ROLE_QTY, DEFAULT_ROLE_EXPIRATION);
+    POLICY.setRoleHolder(tokenVotingCasterRole, llamaERC20TokenCaster, DEFAULT_ROLE_QTY, DEFAULT_ROLE_EXPIRATION);
     vm.stopPrank();
 
-    return (
-      LlamaERC20TokenHolderActionCreator(llamaERC20TokenHolderActionCreator),
-      LlamaERC20TokenHolderCaster(llamaERC20TokenHolderCaster)
-    );
+    return (LlamaERC20TokenActionCreator(llamaERC20TokenActionCreator), LlamaERC20TokenCaster(llamaERC20TokenCaster));
   }
 
   function _deployERC721TokenVotingModuleAndSetRole()
     internal
-    returns (LlamaERC721TokenHolderActionCreator, LlamaERC721TokenHolderCaster)
+    returns (LlamaERC721TokenActionCreator, LlamaERC721TokenCaster)
   {
     vm.startPrank(address(EXECUTOR));
     // Deploy Token Voting Module
-    (address llamaERC721TokenHolderActionCreator, address llamaERC721TokenHolderCaster) = tokenVotingFactory
-      .deployTokenVotingModule(
+    (address llamaERC721TokenActionCreator, address llamaERC721TokenCaster) = tokenVotingFactory.deployTokenVotingModule(
       CORE,
       address(erc721VotesToken),
       false,
@@ -138,19 +133,17 @@ contract LlamaTokenVotingTestSetup is LlamaPeripheryTestSetup, DeployLlamaTokenV
     );
     // Assign roles to Token Voting Modules
     POLICY.setRoleHolder(
-      tokenVotingActionCreatorRole, llamaERC721TokenHolderActionCreator, DEFAULT_ROLE_QTY, DEFAULT_ROLE_EXPIRATION
+      tokenVotingActionCreatorRole, llamaERC721TokenActionCreator, DEFAULT_ROLE_QTY, DEFAULT_ROLE_EXPIRATION
     );
-    POLICY.setRoleHolder(tokenVotingCasterRole, llamaERC721TokenHolderCaster, DEFAULT_ROLE_QTY, DEFAULT_ROLE_EXPIRATION);
+    POLICY.setRoleHolder(tokenVotingCasterRole, llamaERC721TokenCaster, DEFAULT_ROLE_QTY, DEFAULT_ROLE_EXPIRATION);
     vm.stopPrank();
 
-    return (
-      LlamaERC721TokenHolderActionCreator(llamaERC721TokenHolderActionCreator),
-      LlamaERC721TokenHolderCaster(llamaERC721TokenHolderCaster)
-    );
+    return
+      (LlamaERC721TokenActionCreator(llamaERC721TokenActionCreator), LlamaERC721TokenCaster(llamaERC721TokenCaster));
   }
 
-  function _setRolePermissionToLlamaTokenHolderActionCreator() internal {
-    // Assign permission for `MockProtocol.pause` to the LlamaTokenHolderActionCreator.
+  function _setRolePermissionToLlamaTokenActionCreator() internal {
+    // Assign permission for `MockProtocol.pause` to the LlamaTokenActionCreator.
     vm.prank(address(EXECUTOR));
     POLICY.setRolePermission(
       tokenVotingActionCreatorRole,


### PR DESCRIPTION
**Motivation:**

Prefix all contract, variable, and file names with llama to namespace the token voting module and make it easier for developers to recognize this is part of the Llama system when browsing block explorers.

**Modifications:**

- Renamed `src/token-voting/ERC20TokenholderActionCreator.sol` -> `src/token-voting/LlamaERC20TokenActionCreator.sol`
- Renamed `src/token-voting/ERC20TokenholderCaster.sol` -> `src/token-voting/LlamaERC20TokenCaster.sol`
- Renamed `src/token-voting/ERC721TokenholderActionCreator.sol` -> `src/token-voting/LlamaERC721TokenActionCreator.sol`
- Renamed `src/token-voting/ERC721TokenholderCaster.sol` -> `src/token-voting/LlamaERC721TokenCaster.sol`
- Renamed `src/token-voting/TokenholderActionCreator.sol` -> `src/token-voting/LlamaTokenActionCreator.sol`
- Renamed `src/token-voting/TokenholderCaster.sol` -> `src/token-voting/LlamaTokenCaster.sol`- Fixed all corresponding contract and variables names

**Result:**

Closes #9 