### PR TITLE
fix: use `block.timestamp - 1 ` everywhere

### DIFF
--- a/src/token-voting/LlamaERC20TokenActionCreator.sol
+++ b/src/token-voting/LlamaERC20TokenActionCreator.sol
@@ -33,7 +33,7 @@ contract LlamaERC20TokenActionCreator is LlamaTokenActionCreator {
   {
     __initializeLlamaTokenActionCreatorMinimalProxy(_llamaCore, _role, _creationThreshold);
     token = _token;
-    uint256 totalSupply = token.totalSupply();
+    uint256 totalSupply = token.getPastTotalSupply(block.timestamp - 1);
     if (totalSupply == 0) revert InvalidTokenAddress();
     if (_creationThreshold > totalSupply) revert InvalidCreationThreshold();
   }

--- a/src/token-voting/LlamaERC20TokenCaster.sol
+++ b/src/token-voting/LlamaERC20TokenCaster.sol
@@ -35,7 +35,7 @@ contract LlamaERC20TokenCaster is LlamaTokenCaster {
   ) external initializer {
     __initializeLlamaTokenCasterMinimalProxy(_llamaCore, _role, _voteQuorumPct, _vetoQuorumPct);
     token = _token;
-    uint256 totalSupply = token.totalSupply();
+    uint256 totalSupply = token.getPastTotalSupply(block.timestamp - 1);
     if (totalSupply == 0) revert InvalidTokenAddress();
   }
 

--- a/src/token-voting/LlamaERC721TokenCaster.sol
+++ b/src/token-voting/LlamaERC721TokenCaster.sol
@@ -37,6 +37,8 @@ contract LlamaERC721TokenCaster is LlamaTokenCaster {
     __initializeLlamaTokenCasterMinimalProxy(_llamaCore, _role, _voteQuorumPct, _vetoQuorumPct);
     token = _token;
     if (!token.supportsInterface(type(IERC721).interfaceId)) revert InvalidTokenAddress();
+    uint256 totalSupply = token.getPastTotalSupply(block.timestamp - 1);
+    if (totalSupply == 0) revert InvalidTokenAddress();
   }
 
   function _getPastVotes(address account, uint256 timestamp) internal view virtual override returns (uint256) {


### PR DESCRIPTION
**Motivation:**

We need to consistently use `block.timestamp -1` everywhere for all supply checks to prevent any race conditions. Also skimmed all other usages of `block.timestamp` and they are all being used correctly as far as I can tell.

**Modifications:**

* ERC20s supply check at `initialize` uses `block.timestamp -1`
* `LlamaERC721TokenCaster.initialize` also has supply check (This was the only one missing it. 

**Result:**

Closes #22