### PR TITLE
feat: added architecture to support different clock modes

### DIFF
--- a/src/token-voting/LlamaERC20TokenActionCreator.sol
+++ b/src/token-voting/LlamaERC20TokenActionCreator.sol
@@ -49,4 +49,8 @@ contract LlamaERC20TokenActionCreator is LlamaTokenActionCreator {
   function _getClockMode() internal view virtual override returns (string memory) {
     return token.CLOCK_MODE();
   }
+
+  function _getSupportedClockMode() internal pure override returns (string memory) {
+    return "mode=timestamp";
+  }
 }

--- a/src/token-voting/LlamaERC20TokenCaster.sol
+++ b/src/token-voting/LlamaERC20TokenCaster.sol
@@ -50,4 +50,8 @@ contract LlamaERC20TokenCaster is LlamaTokenCaster {
   function _getClockMode() internal view virtual override returns (string memory) {
     return token.CLOCK_MODE();
   }
+
+  function _getSupportedClockMode() internal pure override returns (string memory) {
+    return "mode=timestamp";
+  }
 }

--- a/src/token-voting/LlamaERC721TokenActionCreator.sol
+++ b/src/token-voting/LlamaERC721TokenActionCreator.sol
@@ -51,4 +51,8 @@ contract LlamaERC721TokenActionCreator is LlamaTokenActionCreator {
   function _getClockMode() internal view virtual override returns (string memory) {
     return token.CLOCK_MODE();
   }
+
+  function _getSupportedClockMode() internal pure override returns (string memory) {
+    return "mode=timestamp";
+  }
 }

--- a/src/token-voting/LlamaERC721TokenCaster.sol
+++ b/src/token-voting/LlamaERC721TokenCaster.sol
@@ -52,4 +52,8 @@ contract LlamaERC721TokenCaster is LlamaTokenCaster {
   function _getClockMode() internal view virtual override returns (string memory) {
     return token.CLOCK_MODE();
   }
+
+  function _getSupportedClockMode() internal pure override returns (string memory) {
+    return "mode=timestamp";
+  }
 }

--- a/src/token-voting/LlamaTokenActionCreator.sol
+++ b/src/token-voting/LlamaTokenActionCreator.sol
@@ -220,7 +220,8 @@ abstract contract LlamaTokenActionCreator is Initializable {
   ) internal returns (uint256 actionId) {
     /// @dev only timestamp mode is supported for now
     string memory clockMode = _getClockMode();
-    if (keccak256(abi.encodePacked(clockMode)) != keccak256(abi.encodePacked("mode=timestamp"))) {
+    string memory supportedClockMode = _getSupportedClockMode();
+    if (keccak256(abi.encodePacked(clockMode)) != keccak256(abi.encodePacked(supportedClockMode))) {
       revert ClockModeNotSupported(clockMode);
     }
 
@@ -246,6 +247,7 @@ abstract contract LlamaTokenActionCreator is Initializable {
   function _getPastVotes(address account, uint256 timestamp) internal view virtual returns (uint256) {}
   function _getPastTotalSupply(uint256 timestamp) internal view virtual returns (uint256) {}
   function _getClockMode() internal view virtual returns (string memory) {}
+  function _getSupportedClockMode() internal pure virtual returns (string memory) {}
 
   /// @dev Returns the current nonce for a given tokenHolder and selector, and increments it. Used to prevent
   /// replay attacks.

--- a/src/token-voting/LlamaTokenCaster.sol
+++ b/src/token-voting/LlamaTokenCaster.sol
@@ -274,7 +274,8 @@ abstract contract LlamaTokenCaster is Initializable {
 
     /// @dev only timestamp mode is supported for now.
     string memory clockMode = _getClockMode();
-    if (keccak256(abi.encodePacked(clockMode)) != keccak256(abi.encodePacked("mode=timestamp"))) {
+    string memory supportedClockMode = _getSupportedClockMode();
+    if (keccak256(abi.encodePacked(clockMode)) != keccak256(abi.encodePacked(supportedClockMode))) {
       revert ClockModeNotSupported(clockMode);
     }
 
@@ -308,7 +309,8 @@ abstract contract LlamaTokenCaster is Initializable {
     if (block.timestamp >= action.minExecutionTime) revert SubmissionPeriodOver();
     /// @dev only timestamp mode is supported for now
     string memory clockMode = _getClockMode();
-    if (keccak256(abi.encodePacked(clockMode)) != keccak256(abi.encodePacked("mode=timestamp"))) {
+    string memory supportedClockMode = _getSupportedClockMode();
+    if (keccak256(abi.encodePacked(clockMode)) != keccak256(abi.encodePacked(supportedClockMode))) {
       revert ClockModeNotSupported(clockMode);
     }
 
@@ -377,7 +379,8 @@ abstract contract LlamaTokenCaster is Initializable {
 
     /// @dev only timestamp mode is supported for now.
     string memory clockMode = _getClockMode();
-    if (keccak256(abi.encodePacked(clockMode)) != keccak256(abi.encodePacked("mode=timestamp"))) {
+    string memory supportedClockMode = _getSupportedClockMode();
+    if (keccak256(abi.encodePacked(clockMode)) != keccak256(abi.encodePacked(supportedClockMode))) {
       revert ClockModeNotSupported(clockMode);
     }
 
@@ -395,6 +398,7 @@ abstract contract LlamaTokenCaster is Initializable {
   function _getPastVotes(address account, uint256 timestamp) internal view virtual returns (uint256) {}
   function _getPastTotalSupply(uint256 timestamp) internal view virtual returns (uint256) {}
   function _getClockMode() internal view virtual returns (string memory) {}
+  function _getSupportedClockMode() internal pure virtual returns (string memory) {}
 
   /// @dev Returns the current nonce for a given tokenholder and selector, and increments it. Used to prevent
   /// replay attacks.


### PR DESCRIPTION
**Motivation:**

We want to be able to support non-timestamp clock modes in the future and still be able to inherit the base `LlamaTokenCaster` & `LlamaTokenActionCreator` contracts.

**Modifications:**

- added a virtual `_getSupportedTimestamp` method to the base contracts that is overridden in the final contracts

**Result:**

We can support different clock modes in the future easily