### PR TITLE
refactor: add VoteType enum

### DIFF
--- a/src/lib/Enums.sol
+++ b/src/lib/Enums.sol
@@ -11,3 +11,10 @@ enum ActionState {
   Expired, // block.timestamp is greater than Action's executionTime + expirationDelay.
   Executed // Action has executed successfully.
 }
+
+/// @dev Possible states of a user cast vote.
+enum VoteType {
+  Against,
+  For,
+  Abstain
+}

--- a/src/token-voting/LlamaTokenCaster.sol
+++ b/src/token-voting/LlamaTokenCaster.sol
@@ -5,7 +5,7 @@ import {Initializable} from "@openzeppelin/proxy/utils/Initializable.sol";
 
 import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
 import {ILlamaCore} from "src/interfaces/ILlamaCore.sol";
-import {ActionState} from "src/lib/Enums.sol";
+import {ActionState, VoteType} from "src/lib/Enums.sol";
 import {LlamaUtils} from "src/lib/LlamaUtils.sol";
 import {Action, ActionInfo} from "src/lib/Structs.sol";
 import {ILlamaRelativeStrategyBase} from "src/interfaces/ILlamaRelativeStrategyBase.sol";
@@ -336,9 +336,9 @@ abstract contract LlamaTokenCaster is Initializable {
     uint256 balance = _getPastVotes(caster, action.creationTime - 1);
     _preCastAssertions(balance, support);
 
-    if (support == 0) casts[actionInfo.id].votesAgainst += LlamaUtils.toUint96(balance);
-    else if (support == 1) casts[actionInfo.id].votesFor += LlamaUtils.toUint96(balance);
-    else if (support == 2) casts[actionInfo.id].votesAbstain += LlamaUtils.toUint96(balance);
+    if (support == uint8(VoteType.Against)) casts[actionInfo.id].votesAgainst += LlamaUtils.toUint96(balance);
+    else if (support == uint8(VoteType.For)) casts[actionInfo.id].votesFor += LlamaUtils.toUint96(balance);
+    else if (support == uint8(VoteType.Abstain)) casts[actionInfo.id].votesAbstain += LlamaUtils.toUint96(balance);
     casts[actionInfo.id].castVote[caster] = true;
     emit VoteCast(actionInfo.id, caster, support, balance, reason);
   }
@@ -359,15 +359,15 @@ abstract contract LlamaTokenCaster is Initializable {
     uint256 balance = _getPastVotes(caster, action.creationTime - 1);
     _preCastAssertions(balance, support);
 
-    if (support == 0) casts[actionInfo.id].vetoesAgainst += LlamaUtils.toUint96(balance);
-    else if (support == 1) casts[actionInfo.id].vetoesFor += LlamaUtils.toUint96(balance);
-    else if (support == 2) casts[actionInfo.id].vetoesAbstain += LlamaUtils.toUint96(balance);
+    if (support == uint8(VoteType.Against)) casts[actionInfo.id].vetoesAgainst += LlamaUtils.toUint96(balance);
+    else if (support == uint8(VoteType.For)) casts[actionInfo.id].vetoesFor += LlamaUtils.toUint96(balance);
+    else if (support == uint8(VoteType.Abstain)) casts[actionInfo.id].vetoesAbstain += LlamaUtils.toUint96(balance);
     casts[actionInfo.id].castVeto[caster] = true;
     emit VetoCast(actionInfo.id, caster, support, balance, reason);
   }
 
   function _preCastAssertions(uint256 balance, uint8 support) internal view {
-    if (support > 2) revert InvalidSupport(support);
+    if (support > uint8(VoteType.Abstain)) revert InvalidSupport(support);
 
     /// @dev only timestamp mode is supported for now.
     string memory clockMode = _getClockMode();


### PR DESCRIPTION
**Motivation:**

In an effort to standardize our token voting suite with governor we now compare the support uint8 against a VoteType enum. closes #6

**Modifications:**

- added VoteType to enums lib
- use VoteType to compare suppost in LlamaTokenCaster
- refactored tests to use VoteType where applicable

**Result:**

closes one of the remaining showstopper issues