### PR TITLE
refactor: rename `deployTokenVotingModule` to `deploy`

### DIFF
--- a/src/token-voting/LlamaERC20TokenActionCreator.sol
+++ b/src/token-voting/LlamaERC20TokenActionCreator.sol
@@ -15,14 +15,14 @@ contract LlamaERC20TokenActionCreator is LlamaTokenActionCreator {
   /// @notice The ERC20 token to be used for voting.
   ERC20Votes public token;
 
-  /// @dev This contract is deployed as a minimal proxy from the factory's `deployTokenVotingModule` function. The
+  /// @dev This contract is deployed as a minimal proxy from the factory's `deploy` function. The
   /// `_disableInitializers` locks the implementation (logic) contract, preventing any future initialization of it.
   constructor() {
     _disableInitializers();
   }
 
   /// @notice Initializes a new `LlamaERC20TokenActionCreator` clone.
-  /// @dev This function is called by the `deployTokenVotingModule` function in the `LlamaTokenVotingFactory` contract.
+  /// @dev This function is called by the `deploy` function in the `LlamaTokenVotingFactory` contract.
   /// The `initializer` modifier ensures that this function can be invoked at most once.
   /// @param _token The ERC20 token to be used for voting.
   /// @param _llamaCore The `LlamaCore` contract for this Llama instance.

--- a/src/token-voting/LlamaERC20TokenCaster.sol
+++ b/src/token-voting/LlamaERC20TokenCaster.sol
@@ -15,14 +15,14 @@ contract LlamaERC20TokenCaster is LlamaTokenCaster {
   /// @notice The ERC20 token to be used for voting.
   ERC20Votes public token;
 
-  /// @dev This contract is deployed as a minimal proxy from the factory's `deployTokenVotingModule` function. The
+  /// @dev This contract is deployed as a minimal proxy from the factory's `deploy` function. The
   /// `_disableInitializers` locks the implementation (logic) contract, preventing any future initialization of it.
   constructor() {
     _disableInitializers();
   }
 
   /// @notice Initializes a new `LlamaERC20TokenCaster` clone.
-  /// @dev This function is called by the `deployTokenVotingModule` function in the `LlamaTokenVotingFactory` contract.
+  /// @dev This function is called by the `deploy` function in the `LlamaTokenVotingFactory` contract.
   /// The `initializer` modifier ensures that this function can be invoked at most once.
   /// @param _token The ERC20 token to be used for voting.
   /// @param _llamaCore The `LlamaCore` contract for this Llama instance.

--- a/src/token-voting/LlamaERC721TokenActionCreator.sol
+++ b/src/token-voting/LlamaERC721TokenActionCreator.sol
@@ -16,14 +16,14 @@ contract LlamaERC721TokenActionCreator is LlamaTokenActionCreator {
   /// @notice The ERC721 token to be used for voting.
   ERC721Votes public token;
 
-  /// @dev This contract is deployed as a minimal proxy from the factory's `deployTokenVotingModule` function. The
+  /// @dev This contract is deployed as a minimal proxy from the factory's `deploy` function. The
   /// `_disableInitializers` locks the implementation (logic) contract, preventing any future initialization of it.
   constructor() {
     _disableInitializers();
   }
 
   /// @notice Initializes a new `LlamaERC721TokenActionCreator` clone.
-  /// @dev This function is called by the `deployTokenVotingModule` function in the `LlamaTokenVotingFactory` contract.
+  /// @dev This function is called by the `deploy` function in the `LlamaTokenVotingFactory` contract.
   /// The `initializer` modifier ensures that this function can be invoked at most once.
   /// @param _token The ERC721 token to be used for voting.
   /// @param _llamaCore The `LlamaCore` contract for this Llama instance.

--- a/src/token-voting/LlamaERC721TokenCaster.sol
+++ b/src/token-voting/LlamaERC721TokenCaster.sol
@@ -16,14 +16,14 @@ contract LlamaERC721TokenCaster is LlamaTokenCaster {
   /// @notice The ERC721 token to be used for voting.
   ERC721Votes public token;
 
-  /// @dev This contract is deployed as a minimal proxy from the factory's `deployTokenVotingModule` function. The
+  /// @dev This contract is deployed as a minimal proxy from the factory's `deploy` function. The
   /// `_disableInitializers` locks the implementation (logic) contract, preventing any future initialization of it.
   constructor() {
     _disableInitializers();
   }
 
   /// @notice Initializes a new `LlamaERC721TokenCaster` clone.
-  /// @dev This function is called by the `deployTokenVotingModule` function in the `LlamaTokenVotingFactory` contract.
+  /// @dev This function is called by the `deploy` function in the `LlamaTokenVotingFactory` contract.
   /// The `initializer` modifier ensures that this function can be invoked at most once.
   /// @param _token The ERC721 token to be used for voting.
   /// @param _llamaCore The `LlamaCore` contract for this Llama instance.

--- a/src/token-voting/LlamaTokenVotingFactory.sol
+++ b/src/token-voting/LlamaTokenVotingFactory.sol
@@ -66,7 +66,7 @@ contract LlamaTokenVotingFactory {
   ///@param creationThreshold The number of tokens required to create an action.
   ///@param voteQuorumPct The minimum percentage of tokens required to approve an action.
   ///@param vetoQuorumPct The minimum percentage of tokens required to disapprove an action.
-  function deployTokenVotingModule(
+  function deploy(
     ILlamaCore llamaCore,
     address token,
     ILlamaTokenClockAdapter clockAdapter,

--- a/test/token-voting/LlamaTokenVotingFactory.t.sol
+++ b/test/token-voting/LlamaTokenVotingFactory.t.sol
@@ -69,9 +69,9 @@ contract Constructor is LlamaTokenVotingFactoryTest {
 
 contract DeployTokenVotingModule is LlamaTokenVotingFactoryTest {
   function _setPermissionCreateApproveAndQueueAction(bytes memory data) internal returns (ActionInfo memory actionInfo) {
-    // Assign `deployTokenVotingModule` permission to the `CORE_TEAM_ROLE` role.
+    // Assign `deploy` permission to the `CORE_TEAM_ROLE` role.
     ILlamaPolicy.PermissionData memory deployTokenVotingPermission = ILlamaPolicy.PermissionData(
-      address(tokenVotingFactory), LlamaTokenVotingFactory.deployTokenVotingModule.selector, address(STRATEGY)
+      address(tokenVotingFactory), LlamaTokenVotingFactory.deploy.selector, address(STRATEGY)
     );
 
     vm.prank(address(EXECUTOR));
@@ -91,9 +91,9 @@ contract DeployTokenVotingModule is LlamaTokenVotingFactoryTest {
   }
 
   function test_CanDeployERC20TokenVotingModule() public {
-    // Set up action to call `deployTokenVotingModule` with the ERC20 token.
+    // Set up action to call `deploy` with the ERC20 token.
     bytes memory data = abi.encodeWithSelector(
-      LlamaTokenVotingFactory.deployTokenVotingModule.selector,
+      LlamaTokenVotingFactory.deploy.selector,
       CORE,
       address(erc20VotesToken),
       LLAMA_TOKEN_TIMESTAMP_ADAPTER,
@@ -123,7 +123,7 @@ contract DeployTokenVotingModule is LlamaTokenVotingFactoryTest {
       )
     );
 
-    // Execute call to `deployTokenVotingModule`.
+    // Execute call to `deploy`.
     vm.expectEmit();
     emit ActionThresholdSet(ERC20_CREATION_THRESHOLD);
     vm.expectEmit();
@@ -156,9 +156,9 @@ contract DeployTokenVotingModule is LlamaTokenVotingFactoryTest {
   }
 
   function test_CanDeployERC721TokenVotingModule() public {
-    // Set up action to call `deployTokenVotingModule` with the ERC721 token.
+    // Set up action to call `deploy` with the ERC721 token.
     bytes memory data = abi.encodeWithSelector(
-      LlamaTokenVotingFactory.deployTokenVotingModule.selector,
+      LlamaTokenVotingFactory.deploy.selector,
       CORE,
       address(erc721VotesToken),
       LLAMA_TOKEN_TIMESTAMP_ADAPTER,
@@ -188,7 +188,7 @@ contract DeployTokenVotingModule is LlamaTokenVotingFactoryTest {
       )
     );
 
-    // Execute call to `deployTokenVotingModule`.
+    // Execute call to `deploy`.
     vm.expectEmit();
     emit ActionThresholdSet(ERC721_CREATION_THRESHOLD);
     vm.expectEmit();
@@ -260,7 +260,7 @@ contract DeployTokenVotingModule is LlamaTokenVotingFactoryTest {
     );
 
     vm.prank(randomCaller);
-    tokenVotingFactory.deployTokenVotingModule(
+    tokenVotingFactory.deploy(
       CORE,
       address(erc20VotesToken),
       LLAMA_TOKEN_TIMESTAMP_ADAPTER,
@@ -289,9 +289,9 @@ contract DeployTokenVotingModule is LlamaTokenVotingFactoryTest {
     // First deployment//
     /////////////////////
 
-    // Set up action to call `deployTokenVotingModule` with the ERC20 token.
+    // Set up action to call `deploy` with the ERC20 token.
     bytes memory data = abi.encodeWithSelector(
-      LlamaTokenVotingFactory.deployTokenVotingModule.selector,
+      LlamaTokenVotingFactory.deploy.selector,
       CORE,
       address(erc20VotesToken),
       LLAMA_TOKEN_TIMESTAMP_ADAPTER,
@@ -322,7 +322,7 @@ contract DeployTokenVotingModule is LlamaTokenVotingFactoryTest {
       )
     );
 
-    // Execute call to `deployTokenVotingModule`.
+    // Execute call to `deploy`.
     vm.expectEmit();
     emit LlamaTokenVotingInstanceCreated(
       address(EXECUTOR),
@@ -343,9 +343,9 @@ contract DeployTokenVotingModule is LlamaTokenVotingFactoryTest {
     // Second deployment//
     //////////////////////
 
-    // Set up action to call `deployTokenVotingModule` with the ERC20 token.
+    // Set up action to call `deploy` with the ERC20 token.
     data = abi.encodeWithSelector(
-      LlamaTokenVotingFactory.deployTokenVotingModule.selector,
+      LlamaTokenVotingFactory.deploy.selector,
       CORE,
       address(erc20VotesToken),
       LLAMA_TOKEN_TIMESTAMP_ADAPTER,
@@ -376,7 +376,7 @@ contract DeployTokenVotingModule is LlamaTokenVotingFactoryTest {
       )
     );
 
-    // Execute call to `deployTokenVotingModule`.
+    // Execute call to `deploy`.
     vm.expectEmit();
     emit LlamaTokenVotingInstanceCreated(
       address(EXECUTOR),

--- a/test/token-voting/LlamaTokenVotingTestSetup.sol
+++ b/test/token-voting/LlamaTokenVotingTestSetup.sol
@@ -102,7 +102,7 @@ contract LlamaTokenVotingTestSetup is LlamaPeripheryTestSetup, DeployLlamaTokenV
   {
     vm.startPrank(address(EXECUTOR));
     // Deploy Token Voting Module
-    (address llamaERC20TokenActionCreator, address llamaERC20TokenCaster) = tokenVotingFactory.deployTokenVotingModule(
+    (address llamaERC20TokenActionCreator, address llamaERC20TokenCaster) = tokenVotingFactory.deploy(
       CORE,
       address(erc20VotesToken),
       LLAMA_TOKEN_TIMESTAMP_ADAPTER,
@@ -130,7 +130,7 @@ contract LlamaTokenVotingTestSetup is LlamaPeripheryTestSetup, DeployLlamaTokenV
   {
     vm.startPrank(address(EXECUTOR));
     // Deploy Token Voting Module
-    (address llamaERC721TokenActionCreator, address llamaERC721TokenCaster) = tokenVotingFactory.deployTokenVotingModule(
+    (address llamaERC721TokenActionCreator, address llamaERC721TokenCaster) = tokenVotingFactory.deploy(
       CORE,
       address(erc721VotesToken),
       LLAMA_TOKEN_TIMESTAMP_ADAPTER,


### PR DESCRIPTION
**Motivation:**

pre-audit checklist item

**Modifications:**

rename `deployTokenVotingModule` to `deploy`

**Result:**

deploy fn is more aptly named