### PR TITLE
fix: resolving additional bugs and some refactors

### DIFF
--- a/test/token-voting/LlamaERC721TokenCaster.t.sol
+++ b/test/token-voting/LlamaERC721TokenCaster.t.sol
@@ -145,6 +145,27 @@ contract CastVote is LlamaERC721TokenCasterTest {
     llamaERC721TokenCaster.castVote(actionInfo, uint8(VoteType.For), "");
   }
 
+  function test_RevertsIf_RoleHasBeenRevokedBeforeActionCreation() public {
+    // Revoking Caster role from Token Holder Caster and assigning it to a random address so that Role has supply.
+    vm.startPrank(address(EXECUTOR));
+    POLICY.setRoleHolder(tokenVotingCasterRole, address(llamaERC721TokenCaster), 0, 0);
+    POLICY.setRoleHolder(tokenVotingCasterRole, address(0xdeadbeef), DEFAULT_ROLE_QTY, DEFAULT_ROLE_EXPIRATION);
+    vm.stopPrank();
+
+    // Mine block so that the revoke will be effective
+    mineBlock();
+
+    ActionInfo memory _actionInfo = _createActionWithTokenVotingStrategy(tokenVotingStrategy);
+    Action memory action = CORE.getAction(_actionInfo.id);
+
+    // Skip voting delay
+    vm.warp(action.creationTime + ((APPROVAL_PERIOD * ONE_QUARTER_IN_BPS) / ONE_HUNDRED_IN_BPS) + 1);
+
+    vm.startPrank(tokenHolder1);
+    vm.expectRevert(LlamaTokenCaster.InvalidPolicyholder.selector);
+    llamaERC721TokenCaster.castVote(_actionInfo, uint8(VoteType.For), "");
+  }
+
   function test_RevertsIf_AlreadyCastedVote() public {
     vm.startPrank(tokenHolder1);
     llamaERC721TokenCaster.castVote(actionInfo, uint8(VoteType.For), "");


### PR DESCRIPTION
**Motivation:**

Small codebase changes

**Modifications:**

Bugs:

* Vote weight adding similar to how we do `_newCastCount` in LlamaCore which has an upper bound condition. This will handle cases when someone has quantity greater than `type(uint96).max) - currentCount`. They get to vote too. (This is mostly applicable to ERC20s who can mint huge numbers). Added `test_CanCastWhenCountisMax` tests.
* Due to the way solidity works, we had no way to get the mappings inside the `CastData` struct from an external contract. So added a `hasTokenHolderCast` to `TokenHolderCaster` that gets the values for votes and vetoes. Also added tests.
* Cast Vote and Cast Veto should check if the ActionCaster has the defined `role` at ActionCreation time. Currently the tokenholders will be able to Vote even if the underlying TokenHolderCaster no longer has the role. It'll only fail at Submission time which can be annoying. 

Refactors:

* Removed the `checkIf(Dis)ApprovalEnabled` check in submit functions since they're checked in the underlying `cast` functions in the Llama Framework. Also removed the tests since there is no reasonable way to test this since the `castVote` and `castVeto` functions does have the `checkIf(Dis)ApprovalEnabled` check and it would have failed there. And we know for a fact that the `cast(Dis)approval` being called in the submit functions have the `checkIf(Dis)ApprovalEnabled` check and we have tests for that in the Llama Framework.
* `Note:` We also don't need an Action state check on the submit functions since they're checked in the underlying `cast` functions in the Llama Framework. There is no reasonable way to test this since the `castVote` and `castVeto` functions does have the Action state check and it would have failed there. And we know for a fact that the `cast(Dis)approval` being called in the submit functions have the Action state check and we have tests for that in the Llama Framework.
* Removed the `approvalSubmitted` and `disapprovalSubmitted` bool and respective `AlreadySubmittedApproval` and `AlreadySubmittedDisapproval()` checks. This is since the underlying LlamaFramework handles it through `LlamaCore.DuplicateCast()` error in the worst case. But more likely is that it triggers the `LlamaCore.InvalidActionState` since the state has already transitioned. And we know for a fact that the `cast(Dis)approval` being called in the submit functions have the above checks and we have tests for that in the Llama Framework.

* Combined `AlreadyCastVote()` and `AlreadyCastVeto()` errors into a single `DuplicateCast()` error that matches the error style in Llama Framework and reduces the number of defined errors.
* Combined `ActionNotActive()` and `ActionNotQueued()` errors into a single `InvalidActionState(ActionState current)` error that matches the error style in Llama Framework and reduces the number of defined errors. Moved this into the common `_preCastAssertions` function to match Llama style.
* Changed `VotingDelayNotOver()` error to `DelayPeriodNotOver()` error to match the other Period errors.
* Changed `CannotSubmitYet()` error to `CastingPeriodNotOver()` error to match the other Period errors.


**Result:**

Better and bug free code.