### PR TITLE
feat: llama message broadcaster

### DIFF
--- a/src/message-broadcaster/LlamaMessageBroadcaster.sol
+++ b/src/message-broadcaster/LlamaMessageBroadcaster.sol
@@ -1,14 +1,20 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
+import {ILlamaCore} from "src/interfaces/ILlamaCore.sol";
+import {ILlamaExecutor} from "src/interfaces/ILlamaExecutor.sol";
+
 /// @title LlamaMessageBroadcaster
 /// @author Llama (devsdosomething@llama.xyz)
 /// @notice This contract enables Llama instances to broadcast an offchain message.
 contract LlamaMessageBroadcaster {
-  /// @dev Emitted when a message is broadcast.
-  event LlamaInstanceMessageBroadcasted(address indexed llamaExecutor, string message);
+  /// @dev Emitted when a message is broadcast by a Llama instance.
+  event MessageBroadcasted(ILlamaExecutor indexed llamaExecutor, string message);
 
   function broadcastMessage(string calldata message) external {
-    emit LlamaInstanceMessageBroadcasted(msg.sender, message);
+    ILlamaExecutor llamaExecutor = ILlamaExecutor(msg.sender);
+    // Duck testing to check if the caller is a Llama instance.
+    ILlamaCore(llamaExecutor.LLAMA_CORE()).actionsCount();
+    emit MessageBroadcasted(llamaExecutor, message);
   }
 }

--- a/src/message-broadcaster/LlamaMessageBroadcaster.sol
+++ b/src/message-broadcaster/LlamaMessageBroadcaster.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+/// @title LlamaMessageBroadcaster
+/// @author Llama (devsdosomething@llama.xyz)
+/// @notice This contract enables Llama instances to broadcast an offchain message.
+contract LlamaMessageBroadcaster {
+  /// @dev Emitted when a message is broadcast.
+  event LlamaInstanceMessageBroadcasted(address indexed llamaExecutor, string message);
+
+  function broadcastMessage(string calldata message) external {
+    emit LlamaInstanceMessageBroadcasted(msg.sender, message);
+  }
+}


### PR DESCRIPTION
**Motivation:**

We want to enable llama instances to arbitrarily broadcast messages. This can be used to voice an opinion on a social issue, to recommend an offchain software version number, or to make a prediction. The message can be a structured JSON blob or unstructured prose.  

**Modifications:**

* LlamaMessageBroadcaster peripheral contract.

**Result:**

Llama instances can now broadcast arbitrary offchain messages.