### PR TITLE
docs: add Holesky addresses to `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ The comments in that file explain what each variable is for and when they're nee
 
 ## Testnet deployments
 
-| Name                                             | Sepolia                                                                                                                       | Goerli                                                                                                                       |
+| Name                                             | Sepolia                                                                                                                       | Holesky                                                                                                                       |
 | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | _Factory_|
-| LlamaTokenVotingFactory                          | [0xFBE17545dffD75A92A5A72926AE581478973FE65](https://sepolia.etherscan.io/address/0xFBE17545dffD75A92A5A72926AE581478973FE65) | [0xFBE17545dffD75A92A5A72926AE581478973FE65](https://goerli.etherscan.io/address/0xFBE17545dffD75A92A5A72926AE581478973FE65) |
+| LlamaTokenVotingFactory                          | [0xFBE17545dffD75A92A5A72926AE581478973FE65](https://sepolia.etherscan.io/address/0xFBE17545dffD75A92A5A72926AE581478973FE65) | [0xFBE17545dffD75A92A5A72926AE581478973FE65](https://holesky.etherscan.io/address/0xFBE17545dffD75A92A5A72926AE581478973FE65) |
 | _Governor_|
-| LlamaTokenGovernor (logic contract)              | [0x3f3DAB3ab8cEc2FBd06767c2A5F66Cb6BFF21A4A](https://sepolia.etherscan.io/address/0x3f3DAB3ab8cEc2FBd06767c2A5F66Cb6BFF21A4A) | [0x3f3DAB3ab8cEc2FBd06767c2A5F66Cb6BFF21A4A](https://goerli.etherscan.io/address/0x3f3DAB3ab8cEc2FBd06767c2A5F66Cb6BFF21A4A) |
+| LlamaTokenGovernor (logic contract)              | [0x3f3DAB3ab8cEc2FBd06767c2A5F66Cb6BFF21A4A](https://sepolia.etherscan.io/address/0x3f3DAB3ab8cEc2FBd06767c2A5F66Cb6BFF21A4A) | [0x3f3DAB3ab8cEc2FBd06767c2A5F66Cb6BFF21A4A](https://holesky.etherscan.io/address/0x3f3DAB3ab8cEc2FBd06767c2A5F66Cb6BFF21A4A) |
 | _Token Adapters_|
-| LlamaTokenAdapterVotesTimestamp (logic contract) | [0x088C268cb00226D6A9b29e5488905Aa94D2f0239](https://sepolia.etherscan.io/address/0x088C268cb00226D6A9b29e5488905Aa94D2f0239) | [0x088C268cb00226D6A9b29e5488905Aa94D2f0239](https://goerli.etherscan.io/address/0x088C268cb00226D6A9b29e5488905Aa94D2f0239) |
+| LlamaTokenAdapterVotesTimestamp (logic contract) | [0x088C268cb00226D6A9b29e5488905Aa94D2f0239](https://sepolia.etherscan.io/address/0x088C268cb00226D6A9b29e5488905Aa94D2f0239) | [0x088C268cb00226D6A9b29e5488905Aa94D2f0239](https://holesky.etherscan.io/address/0x088C268cb00226D6A9b29e5488905Aa94D2f0239) |
 
 ## Smart contract reference
 

--- a/justfile
+++ b/justfile
@@ -22,7 +22,7 @@ run-deploy-voting-module-script flags: (run-script 'DeployLlamaTokenVotingModule
 
 dry-run-deploy: (run-script 'DeployLlamaTokenVotingFactory')
 
-deploy: (run-script 'DeployLlamaTokenVotingFactory' '--broadcast --verify --build-info --build-info-path build_info')
+deploy: (run-script 'DeployLlamaTokenVotingFactory' '--broadcast --verify --slow --build-info --build-info-path build_info')
 
 dry-run-deploy-voting-module: (run-deploy-voting-module-script '')
 


### PR DESCRIPTION
**Motivation:**

Updating the `README.md` to add our holesky contract addresses and adding the slow mode flag to the `just deploy` command.

**Modifications:**

Added the holesky contract addresses to the deployment section and added the `--slow` flag to the just deploy command.

**Result:**

Users will be able to find our holesky contract addresses.
